### PR TITLE
Persist confirmed IRS rates; add GitHub push from admin panel

### DIFF
--- a/TaxEstimatorV5.html
+++ b/TaxEstimatorV5.html
@@ -197,6 +197,21 @@ const IRS_SYNC_URL = 'https://raw.githubusercontent.com/kkgeek/tools/main/irs-ra
 const NIIT_THRESHOLD     = {single: 200000, mfj: 250000};
 const ADDL_MED_THRESHOLD = {single: 200000, mfj: 250000};
 
+// JSON helpers — Infinity is not valid JSON; serialize as the string "Infinity"
+const toJson   = data => JSON.stringify(data, (k,v) => v === Infinity ? 'Infinity' : v, 2);
+const fromJson = s    => JSON.parse(s,         (k,v) => v === 'Infinity' ? Infinity : v);
+
+// Rehydrate confirmed year overrides saved by the admin panel — survives page refresh
+try {
+  const _saved = localStorage.getItem('taxSuiteConfirmedYears');
+  if (_saved) {
+    const _overrides = JSON.parse(_saved);
+    for (const [_yr, _jsonStr] of Object.entries(_overrides)) {
+      if (YEARS.includes(Number(_yr))) TAX_DATA[_yr] = fromJson(_jsonStr);
+    }
+  }
+} catch {}
+
 // ================================================================
 // CALCULATOR ENGINE
 // ================================================================
@@ -936,24 +951,54 @@ const YearCompare = ({baseInputs}) => {
 // IRS DATA ADMIN PANEL
 // ================================================================
 const AdminPanel = ({onUpdate}) => {
-  const [yr,      setYr]      = React.useState('2026');
-  const [json,    setJson]    = React.useState('');
-  const [msg,     setMsg]     = React.useState('');
-  const [syncing, setSyncing] = React.useState(false);
-  const [syncMsg, setSyncMsg] = React.useState('');
+  const [yr,       setYr]       = React.useState('2026');
+  const [json,     setJson]     = React.useState('');
+  const [msg,      setMsg]      = React.useState('');
+  const [syncing,  setSyncing]  = React.useState(false);
+  const [syncMsg,  setSyncMsg]  = React.useState('');
   const [syncMeta, setSyncMeta] = React.useState(null);
+  const [patInput, setPatInput] = React.useState('');
+  const [patSaved, setPatSaved] = React.useState(false);
+  const [pushing,  setPushing]  = React.useState(false);
+  const [pushMsg,  setPushMsg]  = React.useState('');
+  const [pushUrl,  setPushUrl]  = React.useState('');
 
-  const toJson   = data => JSON.stringify(data,   (k,v) => v === Infinity ? 'Infinity' : v, 2);
-  const fromJson = s    => JSON.parse(s,           (k,v) => v === 'Infinity' ? Infinity : v);
+  React.useEffect(() => {
+    try {
+      const saved = localStorage.getItem('taxSuiteGitHubPAT');
+      if (saved) { setPatInput(saved); setPatSaved(true); }
+    } catch {}
+  }, []);
 
   React.useEffect(() => { setJson(toJson(TAX_DATA[yr])); setMsg(''); }, [yr]);
+
+  const savePAT = () => {
+    try { localStorage.setItem('taxSuiteGitHubPAT', patInput.trim()); setPatSaved(true); } catch {}
+  };
+
+  const persistOverride = (yrKey, data) => {
+    try {
+      const overrides = JSON.parse(localStorage.getItem('taxSuiteConfirmedYears') || '{}');
+      overrides[yrKey] = toJson(data);
+      localStorage.setItem('taxSuiteConfirmedYears', JSON.stringify(overrides));
+    } catch {}
+  };
+
+  const removeOverride = (yrKey) => {
+    try {
+      const overrides = JSON.parse(localStorage.getItem('taxSuiteConfirmedYears') || '{}');
+      delete overrides[yrKey];
+      localStorage.setItem('taxSuiteConfirmedYears', JSON.stringify(overrides));
+    } catch {}
+  };
 
   const handleSave = () => {
     try {
       const parsed = fromJson(json);
       TAX_DATA[yr] = {...parsed, status: 'confirmed'};
       setJson(toJson(TAX_DATA[yr]));
-      setMsg(`✓ ${yr} saved and marked as confirmed`);
+      persistOverride(yr, TAX_DATA[yr]);
+      setMsg(`✓ ${yr} saved to browser storage and marked confirmed`);
       onUpdate();
     } catch(e) { setMsg(`✗ JSON parse error: ${e.message}`); }
   };
@@ -962,6 +1007,7 @@ const AdminPanel = ({onUpdate}) => {
     const fresh = buildTaxData();
     TAX_DATA[yr] = fresh[yr];
     setJson(toJson(TAX_DATA[yr]));
+    removeOverride(yr);
     setMsg(`↺ ${yr} reset to 2.5% COLA projection`);
     onUpdate();
   };
@@ -980,7 +1026,9 @@ const AdminPanel = ({onUpdate}) => {
         const yNum = Number(fetchedYr);
         if (YEARS.includes(yNum)) {
           const wasConfirmed = TAX_DATA[yNum]?.status === 'confirmed';
-          TAX_DATA[yNum] = {...yrData, status: 'confirmed'};
+          // Round-trip through toJson/fromJson converts "Infinity" strings → Infinity values
+          TAX_DATA[yNum] = fromJson(toJson({...yrData, status: 'confirmed'}));
+          persistOverride(fetchedYr, TAX_DATA[yNum]);
           updatedYears.push(fetchedYr);
           if (wasConfirmed) skippedYears.push(fetchedYr);
         }
@@ -1004,6 +1052,56 @@ const AdminPanel = ({onUpdate}) => {
     }
   };
 
+  const handlePushToGitHub = async () => {
+    const token = patInput.trim();
+    if (!token) { setPushMsg('✗ Enter and save a GitHub PAT first'); return; }
+    setPushing(true);
+    setPushMsg('');
+    setPushUrl('');
+    try {
+      const metaResp = await fetch('https://api.github.com/repos/kkgeek/tools/contents/irs-rates.json', {
+        headers: { Authorization: `token ${token}`, Accept: 'application/vnd.github.v3+json' },
+      });
+      if (!metaResp.ok) throw new Error(`GitHub API ${metaResp.status} — check PAT and repo permissions`);
+      const fileData = await metaResp.json();
+      // Decode existing file to preserve meta fields (irsRP, irsLinks, etc.)
+      const existingContent = decodeURIComponent(escape(atob(fileData.content.replace(/\n/g, ''))));
+      const existingData = fromJson(existingContent);
+      // Merge all confirmed TAX_DATA years into existing data
+      const confirmedYears = {};
+      for (const y of YEARS) {
+        if (TAX_DATA[y]?.status === 'confirmed') confirmedYears[String(y)] = TAX_DATA[y];
+      }
+      const updatedData = {
+        meta: { ...(existingData.meta || {}), lastUpdated: new Date().toISOString().split('T')[0] },
+        years: { ...(existingData.years || {}), ...confirmedYears },
+      };
+      // base64-encode (btoa requires latin1 — encode UTF-8 bytes first)
+      const jsonStr = toJson(updatedData);
+      const base64 = btoa(encodeURIComponent(jsonStr).replace(/%([0-9A-F]{2})/g, (_, h) => String.fromCharCode(parseInt(h, 16))));
+      const putResp = await fetch('https://api.github.com/repos/kkgeek/tools/contents/irs-rates.json', {
+        method: 'PUT',
+        headers: { Authorization: `token ${token}`, Accept: 'application/vnd.github.v3+json', 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          message: `Update IRS rates — ${Object.keys(confirmedYears).join(', ')} confirmed (${new Date().toISOString().split('T')[0]})`,
+          content: base64,
+          sha: fileData.sha,
+        }),
+      });
+      if (!putResp.ok) {
+        const err = await putResp.json().catch(() => ({}));
+        throw new Error(`GitHub API ${putResp.status}: ${err.message || 'unknown error'}`);
+      }
+      const putData = await putResp.json();
+      setPushMsg('✓ Pushed to GitHub');
+      setPushUrl(putData.commit?.html_url || '');
+    } catch(e) {
+      setPushMsg(`✗ Push failed: ${e.message}`);
+    } finally {
+      setPushing(false);
+    }
+  };
+
   const yrOpts = YEARS.map(y => ({v: String(y), l: `${y} — ${TAX_DATA[y].status}`}));
 
   return (
@@ -1011,8 +1109,8 @@ const AdminPanel = ({onUpdate}) => {
       <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-4 text-sm text-amber-800 leading-relaxed">
         <strong>IRS Data Admin</strong> — Projected years (2026–2041) use 2.5% annual COLA from 2025 confirmed data.
         Click <strong>Sync from IRS Data</strong> to pull the latest confirmed rates from the companion <code className="bg-amber-100 px-1 rounded">irs-rates.json</code> file in the repo.
-        To add a new confirmed year, update <code className="bg-amber-100 px-1 rounded">irs-rates.json</code> in GitHub, then Sync.
-        Or paste JSON directly below and click <em>Save &amp; Confirm</em>.
+        Confirmed rates are saved to browser storage and survive page refreshes.
+        Use <strong>Push to GitHub</strong> to commit changes back to the repo (required for other machines to pick them up via Sync).
       </div>
 
       {/* ---- IRS Sync button ---- */}
@@ -1050,6 +1148,55 @@ const AdminPanel = ({onUpdate}) => {
         </div>
       )}
 
+      {/* ---- GitHub Settings ---- */}
+      <Card title="GitHub Settings — Push Confirmed Rates to Repo" titleCls="text-slate-600">
+        <p className="text-xs text-slate-500 mb-3 leading-relaxed">
+          Store a GitHub Personal Access Token (PAT) to commit updated <code className="bg-slate-100 px-1 rounded">irs-rates.json</code> back to the repo. Required to sync confirmed rates across machines. Token stored in browser localStorage — sent only to the GitHub API.
+        </p>
+        <div className="flex gap-2 items-end mb-3">
+          <div className="flex-1">
+            <label className="block text-xs font-medium text-slate-600 mb-1">GitHub PAT (needs <code>repo</code> write scope)</label>
+            <input
+              type="password"
+              className="w-full border border-slate-300 rounded-md px-3 py-1.5 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-400 bg-white"
+              value={patInput}
+              onChange={e => { setPatInput(e.target.value); setPatSaved(false); }}
+              placeholder="ghp_…"
+              autoComplete="off"
+            />
+          </div>
+          <button
+            onClick={savePAT}
+            className={`px-4 py-1.5 rounded-md text-sm font-semibold transition shrink-0 ${
+              patSaved
+                ? 'bg-emerald-100 text-emerald-700 border border-emerald-300'
+                : 'bg-slate-700 hover:bg-slate-800 text-white'
+            }`}
+          >
+            {patSaved ? '✓ Saved' : 'Save PAT'}
+          </button>
+        </div>
+        <button
+          onClick={handlePushToGitHub}
+          disabled={pushing || !patInput.trim()}
+          className="w-full flex items-center justify-center gap-2 bg-violet-600 hover:bg-violet-700 active:bg-violet-800 disabled:bg-violet-300 disabled:cursor-not-allowed text-white rounded-lg py-2.5 text-sm font-bold transition"
+        >
+          {pushing
+            ? <><span className="inline-block animate-spin">↻</span> Pushing to GitHub…</>
+            : '↑ Push All Confirmed Years to GitHub'
+          }
+        </button>
+        {pushMsg && (
+          <div className={`mt-2 text-sm font-semibold ${pushMsg.startsWith('✓') ? 'text-emerald-600' : 'text-red-600'}`}>
+            {pushMsg.startsWith('✓')
+              ? <span>{pushMsg}{pushUrl && <> — <a href={pushUrl} target="_blank" rel="noreferrer" className="underline underline-offset-2 hover:text-emerald-800">view commit ↗</a></>}</span>
+              : pushMsg
+            }
+          </div>
+        )}
+      </Card>
+
+      {/* ---- Manual JSON editor ---- */}
       <Card>
         <Sel label="Select Year to Edit" value={yr} onChange={setYr} options={yrOpts} />
         <div className="flex justify-between items-center mb-2">


### PR DESCRIPTION
## Summary
- **localStorage persistence**: `Save & Mark Confirmed` now writes confirmed year data to `taxSuiteConfirmedYears` in localStorage; on page load `TAX_DATA` is rehydrated from that key so confirmed rates survive refreshes on the same machine
- **GitHub push**: new "GitHub Settings" card in IRS Data Admin — enter a PAT (stored in `taxSuiteGitHubPAT` localStorage), click **↑ Push All Confirmed Years to GitHub** to GET the current `irs-rates.json` SHA, merge all confirmed years in, and PUT it back via the GitHub Contents API with a clickable commit link on success
- **Bug fix**: `handleSync` was passing raw `resp.json()` output into `TAX_DATA`, leaving `"Infinity"` as strings instead of the `Infinity` value the bracket engine expects — fixed by round-tripping through `toJson`/`fromJson`
- `toJson`/`fromJson` helpers moved to module scope (used by both the rehydration boot code and `AdminPanel`)

## Test plan
- [ ] Confirm a projected year via "Save & Mark Confirmed" → refresh page → year still shows as confirmed
- [ ] Reset a confirmed year → refresh → year reverts to projected
- [ ] Sync from IRS Data Source → calculate taxes for a synced year → numbers correct (Infinity bug fix)
- [ ] Enter PAT, save, push → `irs-rates.json` commit appears in GitHub with correct content
- [ ] On a second machine, Sync → picks up the pushed changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)