### PR TITLE
Phase 1: Wealth Suite shell — MD3 dashboard + cross-tool navigation

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Wealth Suite",
+      "runtimeExecutable": "python3",
+      "runtimeArgs": ["-m", "http.server", "3001", "--bind", "127.0.0.1"],
+      "port": 3001
+    }
+  ]
+}

--- a/TaxAssetCalcv4.html
+++ b/TaxAssetCalcv4.html
@@ -30,6 +30,11 @@
             background: #555;
         }
     </style>
+
+    <!-- Wealth Suite shared shell -->
+    <link rel="stylesheet" href="assets/suite.css?v=2">
+    <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
+    <script src="assets/suite.js?v=2" defer></script>
 </head>
 <body class="bg-gray-100 flex items-center justify-center min-h-screen py-8">
     <div id="root"></div>

--- a/TaxEstimatorV5.html
+++ b/TaxEstimatorV5.html
@@ -15,6 +15,11 @@
     ::-webkit-scrollbar-track { background: #f1f5f9; }
     ::-webkit-scrollbar-thumb { background: #94a3b8; border-radius: 3px; }
   </style>
+
+  <!-- Wealth Suite shared shell -->
+  <link rel="stylesheet" href="assets/suite.css?v=2">
+  <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
+  <script src="assets/suite.js?v=2" defer></script>
 </head>
 <body class="bg-slate-50">
 <div id="root"></div>

--- a/assets/suite.css
+++ b/assets/suite.css
@@ -1,0 +1,409 @@
+/* =============================================================
+ * Wealth Suite — shared shell (Material Design 3)
+ * Used by: index.html (full styling) + every tool page (topbar only)
+ * Tools keep their own internal styling; this file only governs
+ * .suite-* elements injected by suite.js.
+ * ============================================================= */
+
+/* ---------- MD3 design tokens ---------- */
+:root {
+  /* Brand: trust-blue primary, prosperity-gold tertiary */
+  --md-sys-color-primary:                   #2C5BAA;
+  --md-sys-color-on-primary:                #FFFFFF;
+  --md-sys-color-primary-container:         #D8E2FF;
+  --md-sys-color-on-primary-container:      #001A41;
+
+  --md-sys-color-secondary:                 #565F71;
+  --md-sys-color-on-secondary:              #FFFFFF;
+  --md-sys-color-secondary-container:       #DAE2F9;
+  --md-sys-color-on-secondary-container:    #131C2B;
+
+  --md-sys-color-tertiary:                  #715573;
+  --md-sys-color-on-tertiary:               #FFFFFF;
+  --md-sys-color-tertiary-container:        #FBD7FB;
+  --md-sys-color-on-tertiary-container:     #29132D;
+
+  --md-sys-color-error:                     #BA1A1A;
+  --md-sys-color-on-error:                  #FFFFFF;
+  --md-sys-color-error-container:           #FFDAD6;
+
+  --md-sys-color-background:                #FAFAFE;
+  --md-sys-color-on-background:             #1A1B20;
+  --md-sys-color-surface:                   #FAFAFE;
+  --md-sys-color-on-surface:                #1A1B20;
+  --md-sys-color-on-surface-variant:        #45464F;
+  --md-sys-color-surface-container-lowest:  #FFFFFF;
+  --md-sys-color-surface-container-low:     #F4F3F8;
+  --md-sys-color-surface-container:         #EEEDF2;
+  --md-sys-color-surface-container-high:    #E8E7EC;
+  --md-sys-color-surface-container-highest: #E2E1E7;
+
+  --md-sys-color-outline:                   #757680;
+  --md-sys-color-outline-variant:           #C5C6D0;
+  --md-sys-color-inverse-surface:           #2F3036;
+  --md-sys-color-inverse-on-surface:        #F1F0F5;
+
+  /* MD3 success palette (extension) */
+  --md-sys-color-success:                   #2E7D32;
+  --md-sys-color-success-container:         #D4EDDA;
+  --md-sys-color-on-success-container:      #0B2912;
+
+  /* Elevation (MD3 5-step) */
+  --md-sys-elevation-0: none;
+  --md-sys-elevation-1: 0 1px 2px 0 rgb(0 0 0 / .12), 0 1px 3px 1px rgb(0 0 0 / .08);
+  --md-sys-elevation-2: 0 1px 2px 0 rgb(0 0 0 / .12), 0 2px 6px 2px rgb(0 0 0 / .10);
+  --md-sys-elevation-3: 0 4px 8px 3px rgb(0 0 0 / .10), 0 1px 3px 0 rgb(0 0 0 / .12);
+  --md-sys-elevation-4: 0 6px 10px 4px rgb(0 0 0 / .10), 0 2px 3px 0 rgb(0 0 0 / .12);
+  --md-sys-elevation-5: 0 8px 12px 6px rgb(0 0 0 / .10), 0 4px 4px 0 rgb(0 0 0 / .12);
+
+  /* Shape (MD3 token scale) */
+  --md-sys-shape-corner-xs:    4px;
+  --md-sys-shape-corner-sm:    8px;
+  --md-sys-shape-corner-md:    12px;
+  --md-sys-shape-corner-lg:    16px;
+  --md-sys-shape-corner-xl:    28px;
+  --md-sys-shape-corner-full:  9999px;
+
+  /* Motion */
+  --md-sys-motion-emphasized:        cubic-bezier(.2, 0, 0, 1);
+  --md-sys-motion-emphasized-decel:  cubic-bezier(.05, .7, .1, 1);
+  --md-sys-motion-standard:          cubic-bezier(.2, 0, 0, 1);
+
+  /* Suite-specific */
+  --suite-topbar-height: 64px;
+  --suite-max-width: 1400px;
+  --suite-content-pad: clamp(16px, 4vw, 32px);
+}
+
+[data-theme="dark"] {
+  --md-sys-color-primary:                   #AFC6FF;
+  --md-sys-color-on-primary:                #002E69;
+  --md-sys-color-primary-container:         #0F4493;
+  --md-sys-color-on-primary-container:      #D8E2FF;
+
+  --md-sys-color-secondary:                 #BEC6DC;
+  --md-sys-color-on-secondary:              #283041;
+  --md-sys-color-secondary-container:       #3E4759;
+  --md-sys-color-on-secondary-container:    #DAE2F9;
+
+  --md-sys-color-tertiary:                  #DEBCDE;
+  --md-sys-color-on-tertiary:               #402843;
+  --md-sys-color-tertiary-container:        #583E5B;
+  --md-sys-color-on-tertiary-container:     #FBD7FB;
+
+  --md-sys-color-error:                     #FFB4AB;
+  --md-sys-color-on-error:                  #690005;
+  --md-sys-color-error-container:           #93000A;
+
+  --md-sys-color-background:                #121318;
+  --md-sys-color-on-background:             #E3E2E9;
+  --md-sys-color-surface:                   #121318;
+  --md-sys-color-on-surface:                #E3E2E9;
+  --md-sys-color-on-surface-variant:        #C5C6D0;
+  --md-sys-color-surface-container-lowest:  #0D0E13;
+  --md-sys-color-surface-container-low:     #1A1B20;
+  --md-sys-color-surface-container:         #1E1F25;
+  --md-sys-color-surface-container-high:    #292A30;
+  --md-sys-color-surface-container-highest: #34353B;
+
+  --md-sys-color-outline:                   #8F909A;
+  --md-sys-color-outline-variant:           #45464F;
+  --md-sys-color-inverse-surface:           #E3E2E9;
+  --md-sys-color-inverse-on-surface:        #2F3036;
+
+  --md-sys-color-success:                   #91D89A;
+  --md-sys-color-success-container:         #1F4A24;
+  --md-sys-color-on-success-container:      #D4EDDA;
+}
+
+/* ---------- Base ---------- */
+html { color-scheme: light; }
+html[data-theme="dark"] { color-scheme: dark; }
+
+body.suite-body {
+  margin: 0;
+  font-family: 'Roboto Flex', 'Roboto', -apple-system, 'Helvetica Neue', Arial, sans-serif;
+  background: var(--md-sys-color-background);
+  color: var(--md-sys-color-on-background);
+  font-feature-settings: "cv11", "ss01";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* ---------- Top app bar (shared across suite + every tool) ----------
+ * Uses fixed positioning so it survives arbitrary body layouts
+ * (e.g. Tailwind `flex items-center justify-center` on the body
+ * would otherwise center a sticky topbar mid-page).
+ * Body gets matching top padding via .suite-body / .suite-tool-shell.
+ */
+html { scroll-padding-top: var(--suite-topbar-height); }
+
+.suite-topbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  background: var(--md-sys-color-surface-container);
+  color: var(--md-sys-color-on-surface);
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  box-shadow: var(--md-sys-elevation-1);
+  height: var(--suite-topbar-height);
+  font-family: 'Roboto Flex', 'Roboto', -apple-system, sans-serif;
+}
+
+/* Compensate for the fixed topbar:
+ *  - .suite-body: applied to the dashboard, takes the padding directly.
+ *  - .suite-tool-shell: added by suite.js to each tool's <body> so the
+ *    tool's first paint isn't tucked under the bar. Works even when
+ *    the tool's body uses display:flex with centered alignment. */
+body.suite-body,
+body.suite-tool-shell {
+  padding-top: var(--suite-topbar-height);
+}
+
+.suite-topbar__inner {
+  height: 100%;
+  max-width: var(--suite-max-width);
+  margin: 0 auto;
+  padding: 0 var(--suite-content-pad);
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.suite-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  color: inherit;
+  flex-shrink: 0;
+}
+.suite-brand__logo {
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  background: var(--md-sys-color-primary);
+  color: var(--md-sys-color-on-primary);
+  border-radius: var(--md-sys-shape-corner-sm);
+  font-weight: 700;
+  font-size: 16px;
+  letter-spacing: -.02em;
+}
+.suite-brand__name {
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -.01em;
+  margin: 0;
+  white-space: nowrap;
+}
+
+.suite-topnav {
+  display: flex;
+  gap: 4px;
+  margin-left: 12px;
+  overflow-x: auto;
+  scrollbar-width: none;
+  flex: 1 1 auto;
+}
+.suite-topnav::-webkit-scrollbar { display: none; }
+
+.suite-topnav__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: var(--md-sys-shape-corner-full);
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: .01em;
+  text-decoration: none;
+  color: var(--md-sys-color-on-surface-variant);
+  white-space: nowrap;
+  transition: background .18s var(--md-sys-motion-standard), color .18s;
+}
+.suite-topnav__link:hover {
+  background: color-mix(in oklab, var(--md-sys-color-on-surface) 8%, transparent);
+  color: var(--md-sys-color-on-surface);
+}
+.suite-topnav__link.is-active {
+  background: var(--md-sys-color-secondary-container);
+  color: var(--md-sys-color-on-secondary-container);
+}
+
+.suite-topbar__spacer { flex: 1; }
+
+.suite-iconbutton {
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  border: none;
+  background: transparent;
+  color: var(--md-sys-color-on-surface-variant);
+  border-radius: var(--md-sys-shape-corner-full);
+  cursor: pointer;
+  transition: background .18s var(--md-sys-motion-standard);
+}
+.suite-iconbutton:hover {
+  background: color-mix(in oklab, var(--md-sys-color-on-surface) 8%, transparent);
+  color: var(--md-sys-color-on-surface);
+}
+.suite-iconbutton svg { width: 22px; height: 22px; }
+
+/* ---------- Dashboard (index.html only) ---------- */
+.suite-main {
+  max-width: var(--suite-max-width);
+  margin: 0 auto;
+  padding: clamp(24px, 5vw, 56px) var(--suite-content-pad) 64px;
+}
+
+.suite-hero {
+  margin-bottom: clamp(32px, 5vw, 56px);
+  max-width: 720px;
+}
+.suite-hero h2 {
+  font-size: clamp(28px, 4vw, 44px);
+  font-weight: 400;
+  line-height: 1.15;
+  letter-spacing: -.02em;
+  margin: 0 0 16px;
+  color: var(--md-sys-color-on-surface);
+}
+.suite-hero h2 strong {
+  font-weight: 600;
+  background: linear-gradient(135deg, var(--md-sys-color-primary), var(--md-sys-color-tertiary));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.suite-hero p {
+  font-size: clamp(15px, 1.6vw, 17px);
+  line-height: 1.55;
+  color: var(--md-sys-color-on-surface-variant);
+  margin: 0;
+}
+
+.suite-section-title {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: var(--md-sys-color-on-surface-variant);
+  margin: 0 0 16px;
+}
+
+/* Responsive grid — 1col mobile, 2col tablet, 3col desktop, 4col wide */
+.suite-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+  margin-bottom: 48px;
+}
+
+.suite-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 20px;
+  min-height: 180px;
+  background: var(--md-sys-color-surface-container-low);
+  color: var(--md-sys-color-on-surface);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: var(--md-sys-shape-corner-lg);
+  text-decoration: none;
+  position: relative;
+  overflow: hidden;
+  transition: box-shadow .24s var(--md-sys-motion-emphasized),
+              transform .24s var(--md-sys-motion-emphasized),
+              background .18s;
+}
+.suite-card:hover {
+  box-shadow: var(--md-sys-elevation-3);
+  transform: translateY(-2px);
+  background: var(--md-sys-color-surface-container);
+}
+.suite-card:focus-visible {
+  outline: 2px solid var(--md-sys-color-primary);
+  outline-offset: 2px;
+}
+
+.suite-card__icon {
+  width: 44px;
+  height: 44px;
+  border-radius: var(--md-sys-shape-corner-md);
+  display: grid;
+  place-items: center;
+  background: var(--md-sys-color-primary-container);
+  color: var(--md-sys-color-on-primary-container);
+}
+.suite-card__icon svg { width: 24px; height: 24px; }
+
+.suite-card[data-accent="tertiary"] .suite-card__icon {
+  background: var(--md-sys-color-tertiary-container);
+  color: var(--md-sys-color-on-tertiary-container);
+}
+.suite-card[data-accent="secondary"] .suite-card__icon {
+  background: var(--md-sys-color-secondary-container);
+  color: var(--md-sys-color-on-secondary-container);
+}
+.suite-card[data-accent="success"] .suite-card__icon {
+  background: var(--md-sys-color-success-container);
+  color: var(--md-sys-color-on-success-container);
+}
+
+.suite-card__title {
+  font-size: 17px;
+  font-weight: 600;
+  line-height: 1.3;
+  letter-spacing: -.005em;
+  margin: 4px 0 0;
+}
+.suite-card__desc {
+  font-size: 13.5px;
+  line-height: 1.5;
+  color: var(--md-sys-color-on-surface-variant);
+  margin: 0;
+  flex: 1;
+}
+.suite-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: auto;
+}
+.suite-card__tag {
+  font-size: 11px;
+  font-weight: 500;
+  padding: 3px 9px;
+  border-radius: var(--md-sys-shape-corner-full);
+  background: color-mix(in oklab, var(--md-sys-color-on-surface) 6%, transparent);
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+/* ---------- Footer ---------- */
+.suite-footer {
+  max-width: var(--suite-max-width);
+  margin: 0 auto;
+  padding: 24px var(--suite-content-pad) 32px;
+  font-size: 12.5px;
+  color: var(--md-sys-color-on-surface-variant);
+  border-top: 1px solid var(--md-sys-color-outline-variant);
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+/* ---------- Print ---------- */
+@media print {
+  .suite-topbar, .suite-footer { display: none; }
+}
+
+/* ---------- Mobile tweaks ---------- */
+@media (max-width: 600px) {
+  .suite-topnav__link { padding: 8px 10px; font-size: 13px; }
+  .suite-brand__name { display: none; }
+}

--- a/assets/suite.js
+++ b/assets/suite.js
@@ -1,0 +1,199 @@
+/* =============================================================
+ * Wealth Suite — shared shell runtime
+ *
+ * Responsibilities:
+ *  1. Resolve theme (system | light | dark), persist user choice,
+ *     apply via [data-theme] on <html>.
+ *  2. On tool pages (where the dashboard hasn't already rendered a
+ *     topbar), inject the suite topbar at <body> start so navigation
+ *     and theme controls are consistent everywhere.
+ *
+ * No framework dependency. Safe to include in pages already running
+ * React, D3, or vanilla — only touches <html data-theme> and the
+ * injected <header class="suite-topbar"> node.
+ * ============================================================= */
+(function () {
+  'use strict';
+
+  const STORAGE_KEY = 'wealthSuite.themePreference';
+  const VALID = ['system', 'light', 'dark'];
+  const mql = window.matchMedia('(prefers-color-scheme: dark)');
+
+  // Tool registry — keep in sync with index.html cards.
+  // `match` is a substring on location.pathname used to highlight the
+  // active link in the injected topbar.
+  const MODULES = [
+    { href: 'index.html',                          label: 'Dashboard',   match: ['index.html', '/'] },
+    { href: 'TaxEstimatorV5.html',                 label: 'Tax',         match: ['TaxEstimatorV5'] },
+    { href: 'TaxAssetCalcv4.html',                 label: 'Assets',      match: ['TaxAssetCalc'] },
+    { href: 'retirement_master_plan_2.html',       label: 'Retirement',  match: ['retirement_master_plan'] },
+    { href: 'portfolio_review.html',               label: 'Portfolio',   match: ['portfolio_review'] },
+    { href: 'golden_ratio_portfolio_dashboard.html', label: 'Golden φ', match: ['golden_ratio'] },
+  ];
+
+  // ---------- Theme ----------
+  function readPreference() {
+    const v = localStorage.getItem(STORAGE_KEY);
+    return VALID.includes(v) ? v : 'system';
+  }
+
+  function resolveTheme(pref) {
+    if (pref === 'system') return mql.matches ? 'dark' : 'light';
+    return pref;
+  }
+
+  function applyTheme() {
+    const pref = readPreference();
+    document.documentElement.setAttribute('data-theme', resolveTheme(pref));
+    document.documentElement.setAttribute('data-theme-pref', pref);
+    // Update toggle button state if mounted
+    document.querySelectorAll('[data-theme-cycle]').forEach((btn) => {
+      btn.setAttribute('aria-label', `Theme: ${pref} (click to change)`);
+      btn.dataset.themePref = pref;
+    });
+  }
+
+  function cycleTheme() {
+    const cur = readPreference();
+    const next = VALID[(VALID.indexOf(cur) + 1) % VALID.length];
+    localStorage.setItem(STORAGE_KEY, next);
+    applyTheme();
+  }
+
+  // React to system changes if user is on "system" preference
+  mql.addEventListener('change', () => {
+    if (readPreference() === 'system') applyTheme();
+  });
+
+  // Apply ASAP — before paint where possible
+  applyTheme();
+
+  // ---------- Topbar injection ----------
+  function currentModuleHref() {
+    const path = location.pathname.toLowerCase();
+    for (const m of MODULES) {
+      if (m.match.some((s) => path.endsWith(s.toLowerCase()) || path.includes('/' + s.toLowerCase()))) {
+        return m.href;
+      }
+    }
+    // Root or unknown — default highlight dashboard
+    if (path.endsWith('/') || path === '') return 'index.html';
+    return null;
+  }
+
+  // Icon set (Material Symbols-inspired SVGs, 24x24)
+  const ICONS = {
+    themeSystem:
+      '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2h-5l1 2h2v2H7v-2h2l1-2H5a2 2 0 0 1-2-2V5zm2 0v10h14V5H5z"/></svg>',
+    themeLight:
+      '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 7a5 5 0 1 0 0 10 5 5 0 0 0 0-10zm0-5a1 1 0 0 1 1 1v2a1 1 0 1 1-2 0V3a1 1 0 0 1 1-1zm0 17a1 1 0 0 1 1 1v2a1 1 0 1 1-2 0v-2a1 1 0 0 1 1-1zM2 12a1 1 0 0 1 1-1h2a1 1 0 1 1 0 2H3a1 1 0 0 1-1-1zm17 0a1 1 0 0 1 1-1h2a1 1 0 1 1 0 2h-2a1 1 0 0 1-1-1zM4.93 4.93a1 1 0 0 1 1.41 0l1.42 1.42a1 1 0 1 1-1.42 1.41L4.93 6.34a1 1 0 0 1 0-1.41zm11.31 11.31a1 1 0 0 1 1.41 0l1.42 1.42a1 1 0 1 1-1.42 1.41l-1.41-1.42a1 1 0 0 1 0-1.41zM19.07 4.93a1 1 0 0 1 0 1.41l-1.42 1.42a1 1 0 1 1-1.41-1.42l1.41-1.41a1 1 0 0 1 1.42 0zM7.76 16.24a1 1 0 0 1 0 1.41l-1.42 1.42a1 1 0 1 1-1.41-1.42l1.41-1.41a1 1 0 0 1 1.42 0z"/></svg>',
+    themeDark:
+      '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M21.64 13a1 1 0 0 0-1.05-.14 8 8 0 1 1-9.45-9.45 1 1 0 0 0-1.2-1.3 10 10 0 1 0 12 12 1 1 0 0 0-.3-1.11z"/></svg>',
+  };
+
+  function themeIcon(pref) {
+    if (pref === 'light') return ICONS.themeLight;
+    if (pref === 'dark')  return ICONS.themeDark;
+    return ICONS.themeSystem;
+  }
+
+  function buildTopbar(options) {
+    const opts = options || {};
+    const activeHref = opts.activeHref || currentModuleHref();
+    const pref = readPreference();
+
+    const header = document.createElement('header');
+    header.className = 'suite-topbar';
+    header.setAttribute('data-suite-injected', opts.injected ? 'true' : 'false');
+
+    const inner = document.createElement('div');
+    inner.className = 'suite-topbar__inner';
+
+    // Brand
+    const brand = document.createElement('a');
+    brand.className = 'suite-brand';
+    brand.href = 'index.html';
+    brand.innerHTML =
+      '<span class="suite-brand__logo" aria-hidden="true">W</span>' +
+      '<h1 class="suite-brand__name">Wealth Suite</h1>';
+    inner.appendChild(brand);
+
+    // Nav links
+    const nav = document.createElement('nav');
+    nav.className = 'suite-topnav';
+    nav.setAttribute('aria-label', 'Module navigation');
+    MODULES.forEach((m) => {
+      const a = document.createElement('a');
+      a.className = 'suite-topnav__link';
+      a.href = m.href;
+      a.textContent = m.label;
+      if (m.href === activeHref) {
+        a.classList.add('is-active');
+        a.setAttribute('aria-current', 'page');
+      }
+      nav.appendChild(a);
+    });
+    inner.appendChild(nav);
+
+    // Theme toggle
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'suite-iconbutton';
+    btn.setAttribute('data-theme-cycle', '');
+    btn.setAttribute('title', 'Cycle theme: system → light → dark');
+    btn.innerHTML = themeIcon(pref);
+    btn.addEventListener('click', () => {
+      cycleTheme();
+      btn.innerHTML = themeIcon(readPreference());
+    });
+    inner.appendChild(btn);
+
+    header.appendChild(inner);
+    return header;
+  }
+
+  function injectTopbarIfMissing() {
+    // If page already has a suite-topbar (e.g. the dashboard rendered
+    // it server-side in markup), only wire up the theme button.
+    const existing = document.querySelector('.suite-topbar');
+    if (existing) {
+      const btn = existing.querySelector('[data-theme-cycle]');
+      if (btn && !btn.dataset.suiteBound) {
+        btn.addEventListener('click', () => {
+          cycleTheme();
+          btn.innerHTML = themeIcon(readPreference());
+        });
+        btn.innerHTML = themeIcon(readPreference());
+        btn.dataset.suiteBound = '1';
+      }
+      return;
+    }
+
+    // Otherwise inject at body start. Topbar is position:fixed (see
+    // suite.css) so it survives flex/centered body layouts. The
+    // matching .suite-tool-shell class adds the 64px top padding so
+    // the tool's own content isn't tucked under the bar.
+    const topbar = buildTopbar({ injected: true });
+    document.body.insertBefore(topbar, document.body.firstChild);
+    document.body.classList.add('suite-tool-shell');
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', injectTopbarIfMissing);
+  } else {
+    injectTopbarIfMissing();
+  }
+
+  // Public API (in case tools want to read theme or rebuild)
+  window.WealthSuite = {
+    getTheme: () => resolveTheme(readPreference()),
+    getPreference: readPreference,
+    setPreference: (p) => {
+      if (!VALID.includes(p)) return;
+      localStorage.setItem(STORAGE_KEY, p);
+      applyTheme();
+    },
+    cycle: cycleTheme,
+    modules: MODULES.slice(),
+  };
+})();

--- a/golden_ratio_portfolio_dashboard.html
+++ b/golden_ratio_portfolio_dashboard.html
@@ -1,4 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Golden φ Portfolio — Wealth Suite</title>
+<style>
+/* Fallback for variables originally provided by Anthropic artifact host */
+:root {
+  --color-text-primary:#1A1B20; --color-text-secondary:#45464F; --color-text-tertiary:#757680;
+  --color-text-success:#2E7D32; --color-text-danger:#BA1A1A; --color-text-warning:#B26B00;
+  --color-background-primary:#FAFAFE; --color-background-secondary:#EEEDF2;
+  --color-background-success:#D4EDDA; --color-background-danger:#FFDAD6; --color-background-warning:#FFE5B4;
+  --color-border-secondary:#C5C6D0; --color-border-tertiary:#E2E1E7;
+  --color-border-success:#91D89A; --color-border-danger:#FF9A92; --color-border-warning:#FFD180;
+  --border-radius-md:12px; --border-radius-lg:16px;
+}
+[data-theme="dark"] {
+  --color-text-primary:#E3E2E9; --color-text-secondary:#C5C6D0; --color-text-tertiary:#8F909A;
+  --color-text-success:#91D89A; --color-text-danger:#FFB4AB; --color-text-warning:#FFCC80;
+  --color-background-primary:#121318; --color-background-secondary:#1E1F25;
+  --color-background-success:#1F4A24; --color-background-danger:#93000A; --color-background-warning:#66431C;
+  --color-border-secondary:#45464F; --color-border-tertiary:#34353B;
+  --color-border-success:#2E7D32; --color-border-danger:#BA1A1A; --color-border-warning:#B26B00;
+}
+*,*::before,*::after{box-sizing:border-box}
+body{margin:0;font-family:'Roboto Flex','Roboto',-apple-system,'Helvetica Neue',Arial,sans-serif;
+     background:var(--color-background-primary);color:var(--color-text-primary);line-height:1.55}
+.golden-content{max-width:1100px;margin:0 auto;padding:24px clamp(16px,4vw,32px) 48px}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+</style>
 
+<!-- Wealth Suite shared shell -->
+<link rel="stylesheet" href="assets/suite.css?v=2">
+<script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
+<script src="assets/suite.js?v=2" defer></script>
+</head>
+<body>
+
+<div class="golden-content">
 <h2 class="sr-only">Golden ratio investment portfolio — φ-derived allocation, 15-year projection, SRR stress test on $100,000 with 5% annual withdrawal</h2>
 <style>
 .m{background:var(--color-background-secondary);border-radius:var(--border-radius-md);padding:12px 14px}
@@ -334,3 +373,7 @@ function upd() {
 ['sI','sW','sY'].forEach(id => document.getElementById(id).addEventListener('input', upd));
 upd();
 </script>
+
+</div>
+</body>
+</html>

--- a/golden_ratio_portfolio_dashboard.html
+++ b/golden_ratio_portfolio_dashboard.html
@@ -1,0 +1,336 @@
+
+<h2 class="sr-only">Golden ratio investment portfolio — φ-derived allocation, 15-year projection, SRR stress test on $100,000 with 5% annual withdrawal</h2>
+<style>
+.m{background:var(--color-background-secondary);border-radius:var(--border-radius-md);padding:12px 14px}
+.ml{font-size:12px;color:var(--color-text-secondary);margin-bottom:3px}
+.mv{font-size:20px;font-weight:500;color:var(--color-text-primary)}
+.ms{font-size:11px;color:var(--color-text-tertiary);margin-top:2px}
+.sec{font-size:11px;font-weight:500;color:var(--color-text-secondary);letter-spacing:.06em;text-transform:uppercase;margin:1.5rem 0 .6rem}
+.leg{display:flex;align-items:center;gap:6px;font-size:12px;color:var(--color-text-secondary)}
+.ld{width:18px;height:3px;border-radius:2px;flex-shrink:0}
+.srow{display:flex;align-items:center;gap:10px;margin-bottom:10px}
+.slbl{font-size:13px;color:var(--color-text-secondary);min-width:130px}
+.sval{font-size:13px;font-weight:500;min-width:72px;text-align:right;color:var(--color-text-primary)}
+.trow{display:grid;grid-template-columns:12px 1fr 68px 56px 72px;gap:8px;align-items:center;padding:9px 14px}
+.trow+.trow{border-top:.5px solid var(--color-border-tertiary)}
+.pc{border-radius:var(--border-radius-lg);padding:14px 16px;border:.5px solid}
+.pc.p{background:var(--color-background-success);border-color:var(--color-border-success)}
+.pc.c{background:var(--color-background-danger);border-color:var(--color-border-danger)}
+.pct{font-size:13px;font-weight:500;margin-bottom:8px}
+.pc.p .pct{color:var(--color-text-success)}
+.pc.c .pct{color:var(--color-text-danger)}
+.pci{font-size:12px;color:var(--color-text-secondary);margin-bottom:5px;padding-left:14px;position:relative;line-height:1.5}
+.pci:before{content:'';position:absolute;left:2px;top:6px;width:5px;height:5px;border-radius:50%}
+.pc.p .pci:before{background:#639922}
+.pc.c .pci:before{background:#E24B4A}
+</style>
+
+<div style="padding:.5rem 0">
+
+<div style="display:flex;align-items:center;gap:18px;margin-bottom:1.5rem">
+  <div style="font-size:64px;font-weight:400;line-height:1;color:#378ADD;font-family:Georgia,serif">φ</div>
+  <div>
+    <div style="font-size:17px;font-weight:500;color:var(--color-text-primary)">Golden ratio investment portfolio</div>
+    <div style="font-size:13px;color:var(--color-text-secondary);margin-top:2px">Allocation weights recursively derived from φ ≈ 1.618 across all asset tiers</div>
+    <code style="font-size:12px;color:var(--color-text-tertiary);background:var(--color-background-secondary);padding:2px 8px;border-radius:4px;display:inline-block;margin-top:4px">1/φ = 61.8%  ·  1/φ² = 23.6%  ·  1/φ³ = 14.6%</code>
+  </div>
+</div>
+
+<div style="display:flex;height:18px;border-radius:9px;overflow:hidden;margin-bottom:10px">
+  <div style="width:38.2%;background:#185FA5"></div>
+  <div style="width:23.6%;background:#378ADD"></div>
+  <div style="width:14.6%;background:#0F6E56"></div>
+  <div style="width:9%;background:#1D9E75"></div>
+  <div style="width:9%;background:#854F0B"></div>
+  <div style="width:5.6%;background:#BA7517"></div>
+</div>
+<div style="display:flex;gap:12px;flex-wrap:wrap;margin-bottom:1.5rem">
+  <span class="leg"><span class="ld" style="background:#185FA5"></span>US equity 38.2%</span>
+  <span class="leg"><span class="ld" style="background:#378ADD"></span>Intl equity 23.6%</span>
+  <span class="leg"><span class="ld" style="background:#0F6E56"></span>Treasuries 14.6%</span>
+  <span class="leg"><span class="ld" style="background:#1D9E75"></span>TIPS 9%</span>
+  <span class="leg"><span class="ld" style="background:#854F0B"></span>Gold 9%</span>
+  <span class="leg"><span class="ld" style="background:#BA7517"></span>REITs 5.6%</span>
+</div>
+
+<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(118px,1fr));gap:10px;margin-bottom:1.5rem">
+  <div class="m"><div class="ml">Blended return</div><div class="mv">7.4%</div><div class="ms">weighted annual</div></div>
+  <div class="m"><div class="ml">Portfolio volatility</div><div class="mv">~10%</div><div class="ms">est. std deviation</div></div>
+  <div class="m"><div class="ml">Sharpe ratio</div><div class="mv">0.29</div><div class="ms">vs 5.5% risk-free</div></div>
+  <div class="m"><div class="ml">Equity weight</div><div class="mv">61.8%</div><div class="ms">exactly 1/φ</div></div>
+  <div class="m"><div class="ml">Depletion risk</div><div class="mv" id="dr" style="color:#BA7517">Moderate</div><div class="ms" id="drs">at 5.0% WR</div></div>
+</div>
+
+<div class="sec">Asset breakdown — recursive φ structure</div>
+<div style="border:.5px solid var(--color-border-tertiary);border-radius:var(--border-radius-lg);overflow:hidden;margin-bottom:1.5rem">
+  <div class="trow" style="background:var(--color-background-secondary)">
+    <div></div>
+    <div style="font-size:11px;font-weight:500;color:var(--color-text-secondary)">Asset class</div>
+    <div style="font-size:11px;font-weight:500;color:var(--color-text-secondary);text-align:right">Alloc</div>
+    <div style="font-size:11px;font-weight:500;color:var(--color-text-secondary);text-align:right">Exp. ret</div>
+    <div style="font-size:11px;font-weight:500;color:var(--color-text-secondary);text-align:right">Amount</div>
+  </div>
+  <div class="trow">
+    <div style="width:10px;height:10px;border-radius:2px;background:#185FA5"></div>
+    <div><div style="font-size:13px;color:var(--color-text-primary)">US equities (S&amp;P 500)</div><div style="font-size:11px;color:var(--color-text-tertiary)">1/φ × equities tier (38.2%)</div></div>
+    <div style="font-size:13px;font-weight:500;color:var(--color-text-primary);text-align:right">38.2%</div>
+    <div style="font-size:12px;color:var(--color-text-secondary);text-align:right">10.0%</div>
+    <div style="font-size:12px;color:var(--color-text-secondary);text-align:right" id="a1">$38,200</div>
+  </div>
+  <div class="trow">
+    <div style="width:10px;height:10px;border-radius:2px;background:#378ADD"></div>
+    <div><div style="font-size:13px;color:var(--color-text-primary)">Intl equities (MSCI ACWI ex-US)</div><div style="font-size:11px;color:var(--color-text-tertiary)">1/φ² × equities tier (23.6%)</div></div>
+    <div style="font-size:13px;font-weight:500;color:var(--color-text-primary);text-align:right">23.6%</div>
+    <div style="font-size:12px;color:var(--color-text-secondary);text-align:right">8.0%</div>
+    <div style="font-size:12px;color:var(--color-text-secondary);text-align:right" id="a2">$23,600</div>
+  </div>
+  <div class="trow">
+    <div style="width:10px;height:10px;border-radius:2px;background:#0F6E56"></div>
+    <div><div style="font-size:13px;color:var(--color-text-primary)">US treasuries / AGG bond index</div><div style="font-size:11px;color:var(--color-text-tertiary)">1/φ × fixed income tier (14.6%)</div></div>
+    <div style="font-size:13px;font-weight:500;color:var(--color-text-primary);text-align:right">14.6%</div>
+    <div style="font-size:12px;color:var(--color-text-secondary);text-align:right">3.5%</div>
+    <div style="font-size:12px;color:var(--color-text-secondary);text-align:right" id="a3">$14,600</div>
+  </div>
+  <div class="trow">
+    <div style="width:10px;height:10px;border-radius:2px;background:#1D9E75"></div>
+    <div><div style="font-size:13px;color:var(--color-text-primary)">TIPS / inflation-linked bonds</div><div style="font-size:11px;color:var(--color-text-tertiary)">1/φ² × fixed income tier (9.0%)</div></div>
+    <div style="font-size:13px;font-weight:500;color:var(--color-text-primary);text-align:right">9.0%</div>
+    <div style="font-size:12px;color:var(--color-text-secondary);text-align:right">4.0%</div>
+    <div style="font-size:12px;color:var(--color-text-secondary);text-align:right" id="a4">$9,000</div>
+  </div>
+  <div class="trow">
+    <div style="width:10px;height:10px;border-radius:2px;background:#854F0B"></div>
+    <div><div style="font-size:13px;color:var(--color-text-primary)">Gold / broad commodities (GLD)</div><div style="font-size:11px;color:var(--color-text-tertiary)">1/φ × alternatives tier (9.0%)</div></div>
+    <div style="font-size:13px;font-weight:500;color:var(--color-text-primary);text-align:right">9.0%</div>
+    <div style="font-size:12px;color:var(--color-text-secondary);text-align:right">5.0%</div>
+    <div style="font-size:12px;color:var(--color-text-secondary);text-align:right" id="a5">$9,000</div>
+  </div>
+  <div class="trow">
+    <div style="width:10px;height:10px;border-radius:2px;background:#BA7517"></div>
+    <div><div style="font-size:13px;color:var(--color-text-primary)">REITs / real assets (VNQ)</div><div style="font-size:11px;color:var(--color-text-tertiary)">1/φ² × alternatives tier (5.6%)</div></div>
+    <div style="font-size:13px;font-weight:500;color:var(--color-text-primary);text-align:right">5.6%</div>
+    <div style="font-size:12px;color:var(--color-text-secondary);text-align:right">7.0%</div>
+    <div style="font-size:12px;color:var(--color-text-secondary);text-align:right" id="a6">$5,600</div>
+  </div>
+  <div class="trow" style="background:var(--color-background-secondary);border-top:.5px solid var(--color-border-secondary)">
+    <div></div>
+    <div style="font-size:12px;font-weight:500;color:var(--color-text-primary)">Total portfolio</div>
+    <div style="font-size:12px;font-weight:500;color:var(--color-text-primary);text-align:right">100%</div>
+    <div style="font-size:12px;font-weight:500;color:var(--color-text-primary);text-align:right">7.4%</div>
+    <div style="font-size:12px;font-weight:500;color:var(--color-text-primary);text-align:right" id="aT">$100,000</div>
+  </div>
+</div>
+
+<div class="sec">Scenario controls</div>
+<div style="display:grid;grid-template-columns:1fr 1fr;gap:20px;margin-bottom:1.5rem">
+  <div>
+    <div class="srow">
+      <span class="slbl">Initial investment</span>
+      <input type="range" min="50000" max="500000" step="10000" value="100000" id="sI" style="flex:1">
+      <span class="sval" id="vI">$100,000</span>
+    </div>
+    <div class="srow">
+      <span class="slbl">Withdrawal rate</span>
+      <input type="range" min="1" max="10" step="0.5" value="5" id="sW" style="flex:1">
+      <span class="sval" id="vW">5.0%</span>
+    </div>
+    <div class="srow">
+      <span class="slbl">Time horizon</span>
+      <input type="range" min="10" max="30" step="1" value="15" id="sY" style="flex:1">
+      <span class="sval" id="vY">15 yrs</span>
+    </div>
+  </div>
+  <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;align-content:start">
+    <div class="m"><div class="ml">Annual withdrawal</div><div class="mv" id="mW">$5,000</div></div>
+    <div class="m"><div class="ml">Base (end value)</div><div class="mv" id="mB" style="color:#378ADD">—</div></div>
+    <div class="m"><div class="ml">SRR favorable</div><div class="mv" id="mF" style="color:#639922">—</div></div>
+    <div class="m"><div class="ml">SRR unfavorable</div><div class="mv" id="mU" style="color:#E24B4A">—</div></div>
+  </div>
+</div>
+
+<div class="sec">Portfolio projection over time</div>
+<div style="display:flex;gap:14px;flex-wrap:wrap;margin-bottom:10px">
+  <span class="leg"><span class="ld" style="background:#378ADD"></span>Base (constant 7.4%)</span>
+  <span class="leg"><span class="ld" style="background:#639922"></span>SRR favorable (high returns early)</span>
+  <span class="leg"><span class="ld" style="background:#E24B4A"></span>SRR unfavorable (low returns early)</span>
+  <span class="leg"><span class="ld" style="background:#888780"></span>Market crash yr 1 (−30%, then +10%)</span>
+</div>
+<div style="position:relative;width:100%;height:320px">
+  <canvas id="pC" role="img" aria-label="Line chart showing 4 portfolio scenarios over time with annual withdrawals starting from $100,000">Portfolio value over time across 4 return scenarios with annual withdrawals.</canvas>
+</div>
+
+<div style="background:var(--color-background-warning);border:.5px solid var(--color-border-warning);border-radius:var(--border-radius-lg);padding:14px 16px;margin-top:1.5rem">
+  <div style="font-size:13px;font-weight:500;color:var(--color-text-warning);margin-bottom:8px">Sequence of returns risk (SRR) — stress test</div>
+  <div style="font-size:12px;color:var(--color-text-secondary);line-height:1.7;margin-bottom:12px">The favorable and unfavorable sequences above use <strong>identical average annual returns</strong> — only the order differs. With no withdrawals, both would produce the same end value. But with a 5% annual withdrawal, early poor returns permanently impair capital before compounding can recover. This is the SRR effect. The golden ratio's 61.8% equity weight creates moderate exposure — less than all-equity, more than a conservative 40/60 portfolio.</div>
+  <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:10px">
+    <div style="background:var(--color-background-primary);border-radius:var(--border-radius-md);padding:10px 12px">
+      <div style="font-size:11px;color:var(--color-text-secondary);margin-bottom:4px">Favorable sequence</div>
+      <div style="font-size:18px;font-weight:500;color:#639922" id="sF">—</div>
+      <div style="font-size:11px;color:var(--color-text-tertiary)">high returns in early years</div>
+    </div>
+    <div style="background:var(--color-background-primary);border-radius:var(--border-radius-md);padding:10px 12px">
+      <div style="font-size:11px;color:var(--color-text-secondary);margin-bottom:4px">Base (constant)</div>
+      <div style="font-size:18px;font-weight:500;color:#378ADD" id="sB">—</div>
+      <div style="font-size:11px;color:var(--color-text-tertiary)">steady 7.4% every year</div>
+    </div>
+    <div style="background:var(--color-background-primary);border-radius:var(--border-radius-md);padding:10px 12px">
+      <div style="font-size:11px;color:var(--color-text-secondary);margin-bottom:4px">Unfavorable sequence</div>
+      <div style="font-size:18px;font-weight:500;color:#E24B4A" id="sU">—</div>
+      <div style="font-size:11px;color:var(--color-text-tertiary)">low returns in early years</div>
+    </div>
+  </div>
+</div>
+
+<div class="sec">Pros &amp; cons</div>
+<div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-bottom:1.5rem">
+  <div class="pc p">
+    <div class="pct">Advantages</div>
+    <div class="pci">Mathematically principled — removes emotional and arbitrary allocation bias</div>
+    <div class="pci">Self-similar structure: same φ ratio governs tier-level and sub-tier splits</div>
+    <div class="pci">61.8% equity delivers strong long-term real return participation</div>
+    <div class="pci">23.6% fixed income provides meaningful drawdown cushion and income</div>
+    <div class="pci">14.6% alternatives adds inflation hedging and low-correlation diversification</div>
+    <div class="pci">Easy to communicate, rebalance, and defend to clients or trustees</div>
+    <div class="pci">φ-based rebalancing bands (±3.8% / ±6.2%) extend the same logic to triggers</div>
+  </div>
+  <div class="pc c">
+    <div class="pct">Disadvantages</div>
+    <div class="pci">No peer-reviewed evidence φ outperforms MPT-optimized or 60/40 portfolios</div>
+    <div class="pci">Ignores investor risk tolerance, tax situation, liquidity horizon, and liabilities</div>
+    <div class="pci">Static weights do not adapt to interest rate or macroeconomic regimes</div>
+    <div class="pci">61.8% equity = moderate-to-high SRR exposure for anyone actively withdrawing</div>
+    <div class="pci">9% alternatives typically requires access to hedge funds, commodity ETFs, or private vehicles</div>
+    <div class="pci">Tax-loss harvesting, Roth conversions, and RMD rules may force deviation from strict ratios</div>
+    <div class="pci">Forward equity return assumption (~10%) faces headwinds from current valuations</div>
+  </div>
+</div>
+
+<div style="font-size:11px;color:var(--color-text-tertiary);padding-top:1rem;border-top:.5px solid var(--color-border-tertiary)">Projections are illustrative estimates using historical return assumptions (US equity 10%, Intl 8%, Treasuries 3.5%, TIPS 4%, Gold 5%, REITs 7%) and do not guarantee future results. SRR scenarios use identical average returns with reversed sequences to isolate the sequence effect. This is educational content, not financial, tax, or legal advice. Consult a licensed financial advisor or tax attorney before making investment decisions.</div>
+
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.js"></script>
+<script>
+const BR = 0.074;
+function makeSeq(n, favourable) {
+  return Array.from({length: n}, (_, i) => {
+    const t = n > 1 ? i / (n - 1) : 0.5;
+    const delta = favourable ? 0.085 * (1 - 2*t) : 0.085 * (2*t - 1);
+    return Math.max(0.005, BR + delta);
+  });
+}
+function makeCrash(n) {
+  return Array.from({length: n}, (_, i) => i === 0 ? -0.30 : 0.10);
+}
+function proj(init, wrPct, yrs, rfn) {
+  const w = init * wrPct / 100;
+  const v = [init];
+  let b = init;
+  for (let y = 0; y < yrs; y++) {
+    b = Math.max(0, b * (1 + rfn(y)) - w);
+    v.push(b);
+  }
+  return v;
+}
+function fmt(n) {
+  if (n <= 0) return '$0';
+  if (n >= 1e6) return '$' + (n/1e6).toFixed(2) + 'M';
+  return '$' + Math.round(n/1000) + 'k';
+}
+function fmtF(n) { return '$' + Math.round(n).toLocaleString(); }
+
+let ch = null;
+function upd() {
+  const init = +document.getElementById('sI').value;
+  const wr   = +document.getElementById('sW').value;
+  const yrs  = +document.getElementById('sY').value;
+
+  document.getElementById('vI').textContent = '$' + init.toLocaleString();
+  document.getElementById('vW').textContent = wr.toFixed(1) + '%';
+  document.getElementById('vY').textContent = yrs + ' yrs';
+
+  [[0.382,'a1'],[0.236,'a2'],[0.146,'a3'],[0.09,'a4'],[0.09,'a5'],[0.056,'a6']].forEach(([p,id]) => {
+    document.getElementById(id).textContent = '$' + Math.round(init*p).toLocaleString();
+  });
+  document.getElementById('aT').textContent = '$' + init.toLocaleString();
+  document.getElementById('mW').textContent = '$' + Math.round(init*wr/100).toLocaleString();
+
+  const de = document.getElementById('dr');
+  document.getElementById('drs').textContent = 'at ' + wr.toFixed(1) + '% WR';
+  if (wr <= 3.5)      { de.textContent='Very low';  de.style.color='#3B6D11'; }
+  else if (wr <= 4.5) { de.textContent='Low';       de.style.color='#639922'; }
+  else if (wr <= 5.5) { de.textContent='Moderate';  de.style.color='#BA7517'; }
+  else if (wr <= 7)   { de.textContent='Elevated';  de.style.color='#993C1D'; }
+  else                { de.textContent='High risk';  de.style.color='#A32D2D'; }
+
+  const favS  = makeSeq(yrs, true);
+  const unfS  = makeSeq(yrs, false);
+  const crS   = makeCrash(yrs);
+  const base  = proj(init, wr, yrs, () => BR);
+  const fav   = proj(init, wr, yrs, i => favS[i]);
+  const unfav = proj(init, wr, yrs, i => unfS[i]);
+  const crash = proj(init, wr, yrs, i => crS[i]);
+  const ref   = Array(yrs + 1).fill(init);
+
+  const lb = base[base.length-1];
+  const lf = fav[fav.length-1];
+  const lu = unfav[unfav.length-1];
+
+  ['mB','sB'].forEach(id => { document.getElementById(id).textContent = fmt(lb); });
+  ['mF','sF'].forEach(id => { document.getElementById(id).textContent = fmt(lf); });
+  ['mU','sU'].forEach(id => { document.getElementById(id).textContent = fmt(lu); });
+
+  const labels = ['Start', ...Array.from({length: yrs}, (_, i) => `Y${i+1}`)];
+  const allDs = [base, fav, unfav, crash, ref];
+
+  if (ch) {
+    ch.data.labels = labels;
+    allDs.forEach((d, i) => { ch.data.datasets[i].data = d; });
+    ch.update();
+    return;
+  }
+
+  ch = new Chart(document.getElementById('pC').getContext('2d'), {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [
+        { label: 'Base (7.4%)',      data: base,  borderColor: '#378ADD', borderWidth: 2.5, fill: false, tension: 0.3, pointRadius: 0, pointHoverRadius: 5 },
+        { label: 'SRR favorable',    data: fav,   borderColor: '#639922', borderWidth: 2,   fill: false, tension: 0.3, pointRadius: 0, pointHoverRadius: 5 },
+        { label: 'SRR unfavorable',  data: unfav, borderColor: '#E24B4A', borderWidth: 2,   fill: false, tension: 0.3, pointRadius: 0, pointHoverRadius: 5 },
+        { label: 'Crash yr 1',       data: crash, borderColor: '#888780', borderWidth: 1.5, borderDash: [5,4], fill: false, tension: 0.3, pointRadius: 0, pointHoverRadius: 5 },
+        { label: 'Initial',          data: ref,   borderColor: 'rgba(136,135,128,0.3)', borderWidth: 1, borderDash: [3,3], fill: false, tension: 0, pointRadius: 0, pointHoverRadius: 0 }
+      ]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { mode: 'index', intersect: false },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          filter: item => item.datasetIndex < 4,
+          callbacks: { label: c => c.dataset.label + ': ' + fmtF(c.raw) }
+        }
+      },
+      scales: {
+        x: {
+          grid: { color: 'rgba(136,135,128,0.1)' },
+          ticks: { color: '#888780', font: { size: 11 }, maxTicksLimit: 12 }
+        },
+        y: {
+          grid: { color: 'rgba(136,135,128,0.1)' },
+          ticks: {
+            color: '#888780',
+            font: { size: 11 },
+            callback: v => v >= 1e6 ? '$'+(v/1e6).toFixed(1)+'M' : '$'+Math.round(v/1000)+'k'
+          }
+        }
+      }
+    }
+  });
+}
+
+['sI','sW','sY'].forEach(id => document.getElementById(id).addEventListener('input', upd));
+upd();
+</script>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Wealth Suite — Personal Finance & Wealth Management</title>
+  <meta name="description" content="Unified Material Design 3 hub for tax estimation, asset planning, retirement, and portfolio review.">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wght@8..144,300..700&display=swap">
+  <link rel="stylesheet" href="assets/suite.css?v=2">
+
+  <!-- Apply theme before paint to avoid flash -->
+  <script>
+    (function () {
+      try {
+        var p = localStorage.getItem('wealthSuite.themePreference');
+        if (!['system','light','dark'].includes(p)) p = 'system';
+        var resolved = p === 'system'
+          ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+          : p;
+        document.documentElement.setAttribute('data-theme', resolved);
+        document.documentElement.setAttribute('data-theme-pref', p);
+      } catch (e) {}
+    })();
+  </script>
+</head>
+<body class="suite-body">
+
+<header class="suite-topbar">
+  <div class="suite-topbar__inner">
+    <a class="suite-brand" href="index.html">
+      <span class="suite-brand__logo" aria-hidden="true">W</span>
+      <h1 class="suite-brand__name">Wealth Suite</h1>
+    </a>
+    <nav class="suite-topnav" aria-label="Module navigation">
+      <a class="suite-topnav__link is-active" href="index.html" aria-current="page">Dashboard</a>
+      <a class="suite-topnav__link" href="TaxEstimatorV5.html">Tax</a>
+      <a class="suite-topnav__link" href="TaxAssetCalcv4.html">Assets</a>
+      <a class="suite-topnav__link" href="retirement_master_plan_2.html">Retirement</a>
+      <a class="suite-topnav__link" href="portfolio_review.html">Portfolio</a>
+      <a class="suite-topnav__link" href="golden_ratio_portfolio_dashboard.html">Golden φ</a>
+    </nav>
+    <button type="button" class="suite-iconbutton" data-theme-cycle
+            title="Cycle theme: system → light → dark"
+            aria-label="Toggle theme">
+      <!-- Filled by suite.js on load -->
+      <svg viewBox="0 0 24 24" fill="currentColor" width="22" height="22"><path d="M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2h-5l1 2h2v2H7v-2h2l1-2H5a2 2 0 0 1-2-2V5zm2 0v10h14V5H5z"/></svg>
+    </button>
+  </div>
+</header>
+
+<main class="suite-main">
+
+  <section class="suite-hero">
+    <h2>Your <strong>personal finance</strong> command center.</h2>
+    <p>A unified Material Design 3 hub for tax estimation, asset planning, retirement modeling, and portfolio review. Every tool runs locally in your browser — your data stays on your device.</p>
+  </section>
+
+  <h3 class="suite-section-title">Modules</h3>
+  <section class="suite-grid" aria-label="Modules">
+
+    <a class="suite-card" href="TaxEstimatorV5.html" data-accent="primary">
+      <span class="suite-card__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6zm-1 7V3.5L18.5 9H13zM8 13h8v2H8v-2zm0 4h5v2H8v-2zm0-8h3v2H8V9z"/></svg>
+      </span>
+      <h4 class="suite-card__title">Tax Estimator</h4>
+      <p class="suite-card__desc">Federal &amp; WA tax, brackets, AMT, LTCG/NIIT, supplemental gap, quarterly payments. 2024–2041.</p>
+      <div class="suite-card__tags">
+        <span class="suite-card__tag">Federal</span>
+        <span class="suite-card__tag">WA State</span>
+        <span class="suite-card__tag">React</span>
+      </div>
+    </a>
+
+    <a class="suite-card" href="TaxAssetCalcv4.html" data-accent="secondary">
+      <span class="suite-card__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M3 13h2v8H3v-8zm4-4h2v12H7V9zm4-4h2v16h-2V5zm4 2h2v14h-2V7zm4 4h2v10h-2V11z"/></svg>
+      </span>
+      <h4 class="suite-card__title">Asset &amp; Cap-Gains Calculator</h4>
+      <p class="suite-card__desc">Capital gains scenarios with D3 visualizations — short vs. long-term, lot selection, tax-loss harvesting.</p>
+      <div class="suite-card__tags">
+        <span class="suite-card__tag">D3</span>
+        <span class="suite-card__tag">Scenarios</span>
+      </div>
+    </a>
+
+    <a class="suite-card" href="retirement_master_plan_2.html" data-accent="success">
+      <span class="suite-card__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm1 17.93V18a1 1 0 0 0-2 0v1.93A8 8 0 0 1 4.07 13H6a1 1 0 0 0 0-2H4.07A8 8 0 0 1 11 4.07V6a1 1 0 0 0 2 0V4.07A8 8 0 0 1 19.93 11H18a1 1 0 0 0 0 2h1.93A8 8 0 0 1 13 19.93zM12 8a4 4 0 1 0 4 4 4 4 0 0 0-4-4z"/></svg>
+      </span>
+      <h4 class="suite-card__title">Retirement Master Plan</h4>
+      <p class="suite-card__desc">Long-horizon projections for a married couple — contributions, growth assumptions, withdrawal phasing.</p>
+      <div class="suite-card__tags">
+        <span class="suite-card__tag">Projections</span>
+        <span class="suite-card__tag">WA Couple</span>
+      </div>
+    </a>
+
+    <a class="suite-card" href="portfolio_review.html" data-accent="tertiary">
+      <span class="suite-card__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M21 3H3a1 1 0 0 0-1 1v16a1 1 0 0 0 1 1h18a1 1 0 0 0 1-1V4a1 1 0 0 0-1-1zM9 18H5v-4h4v4zm0-6H5V8h4v4zm10 6h-8v-4h8v4zm0-6h-8V8h8v4z"/></svg>
+      </span>
+      <h4 class="suite-card__title">Portfolio Review</h4>
+      <p class="suite-card__desc">Diversification analysis, concentration risk, sector &amp; geography breakdowns with rebalancing prompts.</p>
+      <div class="suite-card__tags">
+        <span class="suite-card__tag">Allocation</span>
+        <span class="suite-card__tag">Risk</span>
+      </div>
+    </a>
+
+    <a class="suite-card" href="golden_ratio_portfolio_dashboard.html" data-accent="tertiary">
+      <span class="suite-card__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 3a9 9 0 1 0 9 9 9 9 0 0 0-9-9zm0 16a7 7 0 1 1 7-7 7 7 0 0 1-7 7zm3.5-7a3.5 3.5 0 1 1-3.5-3.5 3.5 3.5 0 0 1 3.5 3.5z"/></svg>
+      </span>
+      <h4 class="suite-card__title">Golden φ Portfolio</h4>
+      <p class="suite-card__desc">Phi-derived allocation, 15-year projection, sequence-of-returns stress test on $100K with 5% withdrawal.</p>
+      <div class="suite-card__tags">
+        <span class="suite-card__tag">Allocation</span>
+        <span class="suite-card__tag">SRR</span>
+      </div>
+    </a>
+
+  </section>
+
+  <h3 class="suite-section-title">Reference data</h3>
+  <section class="suite-grid" aria-label="Reference">
+    <a class="suite-card" href="irs-rates.json" data-accent="secondary">
+      <span class="suite-card__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M19 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zm-7 14H7v-2h5v2zm0-4H7v-2h5v2zm0-4H7V7h5v2zm5 8h-3v-2h3v2zm0-4h-3v-2h3v2zm0-4h-3V7h3v2z"/></svg>
+      </span>
+      <h4 class="suite-card__title">IRS Rates Data</h4>
+      <p class="suite-card__desc">Auto-synced tax brackets, standard deductions, contribution limits. Tax Estimator pulls from this on startup.</p>
+      <div class="suite-card__tags">
+        <span class="suite-card__tag">2024–2041</span>
+        <span class="suite-card__tag">JSON</span>
+      </div>
+    </a>
+  </section>
+
+</main>
+
+<footer class="suite-footer">
+  <span>Wealth Suite — runs entirely in your browser. No tracking, no upload.</span>
+  <span>Material Design 3 · Responsive · GitHub Pages ready</span>
+</footer>
+
+<script src="assets/suite.js?v=2" defer></script>
+</body>
+</html>

--- a/portfolio_review.html
+++ b/portfolio_review.html
@@ -76,6 +76,11 @@ body{font-family:'DM Sans',sans-serif;background:var(--bg);color:var(--text);fon
 .dl-val{font-family:'JetBrains Mono',monospace;margin-left:auto;padding-left:14px;font-size:12px}
 @media(max-width:600px){.main{padding:16px}.g4{grid-template-columns:1fr 1fr}.hld-row{grid-template-columns:55px 1fr 80px 60px;gap:4px}.hld-act{display:none}.etf-row{grid-template-columns:70px 1fr 60px}}
 </style>
+
+<!-- Wealth Suite shared shell -->
+<link rel="stylesheet" href="assets/suite.css?v=2">
+<script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
+<script src="assets/suite.js?v=2" defer></script>
 </head>
 <body>
 

--- a/portfolio_review.html
+++ b/portfolio_review.html
@@ -1,0 +1,412 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Portfolio Review & Diversification Strategy</title>
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{
+  --bg:#0C0F14;--surface:#151920;--surface2:#1C2028;--border:#262D3A;
+  --text:#E4E8EF;--muted:#8892A4;--hint:#5A6376;
+  --blue:#4B8BF5;--green:#34D399;--amber:#FBBF24;--red:#F87171;--purple:#A78BFA;--cyan:#22D3EE;
+  --green-bg:rgba(52,211,153,0.1);--green-t:#34D399;
+  --amber-bg:rgba(251,191,36,0.1);--amber-t:#FBBF24;
+  --red-bg:rgba(248,113,113,0.1);--red-t:#F87171;
+  --blue-bg:rgba(75,139,245,0.1);--blue-t:#4B8BF5;
+}
+body{font-family:'DM Sans',sans-serif;background:var(--bg);color:var(--text);font-size:14px;line-height:1.6;min-height:100vh}
+.hdr{background:linear-gradient(135deg,#0F1923 0%,#162032 100%);padding:24px 32px;border-bottom:1px solid var(--border)}
+.hdr h1{font-size:18px;font-weight:700;margin-bottom:3px}
+.hdr p{font-size:12px;color:var(--muted)}
+.nav{background:var(--surface);border-bottom:1px solid var(--border);padding:0 28px;display:flex;overflow-x:auto;gap:2px}
+.nb{padding:12px 16px;border:none;background:transparent;color:var(--hint);cursor:pointer;font-size:12px;font-weight:600;border-bottom:2px solid transparent;white-space:nowrap;font-family:inherit;transition:all .15s;text-transform:uppercase;letter-spacing:.06em}
+.nb:hover{color:var(--muted)}.nb.on{color:var(--cyan);border-bottom-color:var(--cyan)}
+.main{padding:24px 32px;max-width:980px;margin:0 auto}
+.pane{display:none}.pane.on{display:block}
+.g4{display:grid;grid-template-columns:repeat(auto-fit,minmax(145px,1fr));gap:10px;margin-bottom:16px}
+.sc{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:13px 15px}
+.sc-l{font-size:10px;color:var(--hint);margin-bottom:4px;text-transform:uppercase;letter-spacing:.06em;font-weight:600}
+.sc-v{font-size:20px;font-weight:700;font-family:'JetBrains Mono',monospace}
+.card{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:18px 20px;margin-bottom:14px}
+.ct{font-size:14px;font-weight:700;margin-bottom:4px}
+.cs{font-size:12px;color:var(--muted);margin-bottom:14px}
+.bdg{display:inline-block;font-size:10px;font-weight:600;padding:3px 9px;border-radius:20px;flex-shrink:0;text-transform:uppercase;letter-spacing:.04em}
+.bdg-r{background:var(--red-bg);color:var(--red-t)}.bdg-a{background:var(--amber-bg);color:var(--amber-t)}
+.bdg-b{background:var(--blue-bg);color:var(--blue-t)}.bdg-g{background:var(--green-bg);color:var(--green-t)}
+.ri{display:flex;align-items:flex-start;gap:11px;padding:10px 0;border-bottom:1px solid var(--border)}
+.ri:last-child{border-bottom:none}
+.ri-t{flex:1;font-size:13px;color:var(--muted);line-height:1.6}
+.ib{border-radius:8px;padding:11px 14px;font-size:12px;line-height:1.7;margin-top:10px}
+.ib-r{background:var(--red-bg);color:var(--red-t)}.ib-g{background:var(--green-bg);color:var(--green-t)}
+.ib-a{background:var(--amber-bg);color:var(--amber-t)}.ib-b{background:var(--blue-bg);color:var(--blue-t)}
+.bar-w{margin-bottom:12px}
+.bar-h{display:flex;justify-content:space-between;font-size:12px;margin-bottom:4px;color:var(--muted)}
+.bar-h span:last-child{font-family:'JetBrains Mono',monospace;font-weight:500;color:var(--text)}
+.bar{height:8px;background:var(--border);border-radius:4px;overflow:hidden;position:relative}
+.bar-f{height:100%;border-radius:4px;transition:width .6s}
+.bar-t{position:absolute;top:0;bottom:0;width:2px;background:var(--text);opacity:.5}
+.hld-row{display:grid;grid-template-columns:60px 1fr 90px 70px 80px;align-items:center;padding:8px 0;border-bottom:1px solid var(--border);font-size:12px}
+.hld-row:last-child{border-bottom:none}
+.hld-tk{font-family:'JetBrains Mono',monospace;font-weight:600;font-size:12px;color:var(--cyan)}
+.hld-nm{color:var(--muted);font-size:11px}
+.hld-val{font-family:'JetBrains Mono',monospace;text-align:right;font-size:12px}
+.hld-pct{text-align:right;font-size:11px;color:var(--muted)}
+.hld-act{text-align:right;font-size:11px}
+.phase{border-left:3px solid;padding:12px 14px;border-radius:0 8px 8px 0;margin-bottom:10px;background:var(--surface2)}
+.phase-hd{display:flex;justify-content:space-between;align-items:center;margin-bottom:6px;flex-wrap:wrap;gap:6px}
+.phase-t{font-size:13px;font-weight:700}.phase-b{font-size:12px;color:var(--muted);line-height:1.7}
+.etf-row{display:grid;grid-template-columns:80px 1fr 80px 60px;align-items:center;padding:9px 0;border-bottom:1px solid var(--border);font-size:12px;gap:10px}
+.etf-row:last-child{border-bottom:none}
+.etf-tk{font-family:'JetBrains Mono',monospace;font-weight:600;color:var(--green)}
+.etf-nm{color:var(--muted);font-size:11px;line-height:1.4}
+.etf-er{font-family:'JetBrains Mono',monospace;text-align:right;font-size:11px;color:var(--muted)}
+.etf-risk{text-align:right;font-size:11px}
+.risk1{color:#34D399}.risk2{color:#6EE7B7}.risk3{color:#FBBF24}.risk4{color:#FB923C}.risk5{color:#F87171}
+.cmp-tbl{width:100%;border-collapse:collapse;font-size:12px;margin-top:8px}
+.cmp-tbl th{text-align:left;padding:8px 10px;background:var(--surface2);font-weight:600;font-size:10px;text-transform:uppercase;letter-spacing:.06em;color:var(--hint);border-bottom:1px solid var(--border)}
+.cmp-tbl td{padding:8px 10px;border-bottom:1px solid var(--border);color:var(--muted);vertical-align:top;line-height:1.5}
+.cmp-tbl tr:last-child td{border-bottom:none}
+.cmp-tbl td:first-child{font-weight:600;color:var(--text);white-space:nowrap}
+.donut-wrap{display:flex;align-items:center;gap:24px;margin:14px 0}
+.donut-legend{display:flex;flex-direction:column;gap:6px;font-size:12px}
+.dl-i{display:flex;align-items:center;gap:8px}
+.dl-dot{width:10px;height:10px;border-radius:3px;flex-shrink:0}
+.dl-val{font-family:'JetBrains Mono',monospace;margin-left:auto;padding-left:14px;font-size:12px}
+@media(max-width:600px){.main{padding:16px}.g4{grid-template-columns:1fr 1fr}.hld-row{grid-template-columns:55px 1fr 80px 60px;gap:4px}.hld-act{display:none}.etf-row{grid-template-columns:70px 1fr 60px}}
+</style>
+</head>
+<body>
+
+<div class="hdr">
+  <h1>Portfolio Review & Diversification Strategy</h1>
+  <p>$4,746,132 &middot; 140+ holdings &middot; As of May 3, 2026 &middot; Prepared for retirement at 55</p>
+</div>
+
+<div class="nav">
+  <button class="nb on" onclick="showTab('dx',this)">Diagnosis</button>
+  <button class="nb" onclick="showTab('conc',this)">Concentration</button>
+  <button class="nb" onclick="showTab('target',this)">Target allocation</button>
+  <button class="nb" onclick="showTab('etfs',this)">ETF picks</button>
+  <button class="nb" onclick="showTab('plan',this)">Diversification plan</button>
+  <button class="nb" onclick="showTab('tail',this)">Tail cleanup</button>
+</div>
+
+<div class="main">
+
+<!-- DIAGNOSIS -->
+<div id="dx" class="pane on">
+  <div class="g4">
+    <div class="sc"><div class="sc-l">Total portfolio</div><div class="sc-v" style="color:var(--text)">$4.75M</div></div>
+    <div class="sc"><div class="sc-l">Individual stocks</div><div class="sc-v" style="color:var(--amber)">140+</div></div>
+    <div class="sc"><div class="sc-l">Top 5 = % of portfolio</div><div class="sc-v" style="color:var(--red)">38.0%</div></div>
+    <div class="sc"><div class="sc-l">Tech concentration</div><div class="sc-v" style="color:var(--red)">~49%</div></div>
+    <div class="sc"><div class="sc-l">Bonds + cash</div><div class="sc-v" style="color:var(--amber)">6.8%</div></div>
+    <div class="sc"><div class="sc-l">International</div><div class="sc-v" style="color:var(--amber)">14.2%</div></div>
+    <div class="sc"><div class="sc-l">Positions < $5k</div><div class="sc-v" style="color:var(--red)">80+</div></div>
+    <div class="sc"><div class="sc-l">Buffer readiness</div><div class="sc-v" style="color:var(--red)">$322k/$861k</div></div>
+  </div>
+
+  <div class="card">
+    <div class="ct">Portfolio health — 5 critical findings</div>
+    <div class="cs">Your portfolio has excellent growth potential but carries structural risks that must be addressed before retirement in 4 years.</div>
+
+    <div class="ri"><span class="bdg bdg-r">Critical</span><span class="ri-t"><strong style="color:var(--text)">Mega-cap tech concentration: ~49% of portfolio.</strong> GOOG ($470k), META ($430k), MSFT ($355k), AMZN ($303k), NVDA ($247k) alone = 38%. Add AAPL, AVGO, AMD, ANET, MU, SMH, and the ~55% tech overlap in Fidelity Growth Commingled ($648k) and QQQ ($40k) — your total tech exposure is nearly half the portfolio. A 2022-style tech correction (-30%) would wipe $700k+ in months. This must be diversified before retirement.</span></div>
+
+    <div class="ri"><span class="bdg bdg-r">Critical</span><span class="ri-t"><strong style="color:var(--text)">140+ positions with 80+ under $5k — extreme fragmentation.</strong> Positions like BBWI ($475), TTD ($275), BKNG ($212), LPLA ($159), CEG ($388), Z ($504) create tax reporting complexity, rebalancing friction, and management overhead with near-zero impact on returns. Every one of these generates a 1099 line. This is a portfolio that grew organically without pruning — it needs a cleanup before the simpler retirement phase.</span></div>
+
+    <div class="ri"><span class="bdg bdg-a">High</span><span class="ri-t"><strong style="color:var(--text)">Bond/cash allocation at 6.8% — far below the 17% needed at retirement.</strong> You need $861k in the 3-tier buffer by age 55. Currently: Stable Value ($206k) + SPAXX ($54k) + Cash ($24k) + BND/BNDX/SCHP ($5.5k) + CDs ($2k) ≈ $292k. You need to build ~$570k more over 4 years — about $143k/yr moved from equities to buffer instruments, timed to coincide with rebalancing and TLH opportunities.</span></div>
+
+    <div class="ri"><span class="bdg bdg-a">High</span><span class="ri-t"><strong style="color:var(--text)">International at 14.2% — underweight vs. global market cap (~40%).</strong> VXUS ($223k), VEA ($26k), VWO ($14k), intl funds ($245k), plus some ADRs. Target: 20% of equity sleeve = ~$780k. You're ~$200k short. The good news: concentrated US tech positions you'll be trimming can rotate partly into international ETFs.</span></div>
+
+    <div class="ri"><span class="bdg bdg-b">Medium</span><span class="ri-t"><strong style="color:var(--text)">Overlapping index exposure creates hidden costs.</strong> You hold VOO, VTI, VFFSX, VANG 500 IDX, VOOG, SPYG, VUG, VV — these are all large-cap US equity with 90%+ correlation. Combined ~$216k across 7 funds doing the same thing. Consolidate into 1–2 core positions to reduce tax lot complexity and make rebalancing tractable.</span></div>
+  </div>
+
+  <div class="card">
+    <div class="ct">Current vs. target allocation</div>
+    <div class="cs">Shift from 92% equity / 7% bonds+cash to 82% equity / 18% buffer over 4 years</div>
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:14px">
+      <div>
+        <div style="font-size:11px;font-weight:600;color:var(--hint);text-transform:uppercase;letter-spacing:.06em;margin-bottom:10px">Current allocation</div>
+        <div class="bar-w"><div class="bar-h"><span>US stocks</span><span>78.2%</span></div><div class="bar"><div class="bar-f" style="width:78.2%;background:var(--blue)"></div></div></div>
+        <div class="bar-w"><div class="bar-h"><span>Intl stocks</span><span>13.8%</span></div><div class="bar"><div class="bar-f" style="width:13.8%;background:var(--cyan)"></div></div></div>
+        <div class="bar-w"><div class="bar-h"><span>US bonds</span><span>4.3%</span></div><div class="bar"><div class="bar-f" style="width:4.3%;background:var(--green)"></div></div></div>
+        <div class="bar-w"><div class="bar-h"><span>Cash</span><span>2.1%</span></div><div class="bar"><div class="bar-f" style="width:2.1%;background:var(--amber)"></div></div></div>
+        <div class="bar-w"><div class="bar-h"><span>Other</span><span>1.6%</span></div><div class="bar"><div class="bar-f" style="width:1.6%;background:var(--hint)"></div></div></div>
+      </div>
+      <div>
+        <div style="font-size:11px;font-weight:600;color:var(--hint);text-transform:uppercase;letter-spacing:.06em;margin-bottom:10px">Target at retirement (age 55)</div>
+        <div class="bar-w"><div class="bar-h"><span>US stocks</span><span style="color:var(--green)">55%</span></div><div class="bar"><div class="bar-f" style="width:55%;background:var(--blue)"></div><div class="bar-t" style="left:78.2%"></div></div></div>
+        <div class="bar-w"><div class="bar-h"><span>Intl stocks</span><span style="color:var(--green)">20%</span></div><div class="bar"><div class="bar-f" style="width:20%;background:var(--cyan)"></div><div class="bar-t" style="left:13.8%"></div></div></div>
+        <div class="bar-w"><div class="bar-h"><span>3-yr buffer (bonds/CDs/MM)</span><span style="color:var(--green)">18%</span></div><div class="bar"><div class="bar-f" style="width:18%;background:var(--green)"></div><div class="bar-t" style="left:6.4%"></div></div></div>
+        <div class="bar-w"><div class="bar-h"><span>Small/mid-cap tilt</span><span style="color:var(--green)">5%</span></div><div class="bar"><div class="bar-f" style="width:5%;background:var(--purple)"></div></div></div>
+        <div class="bar-w"><div class="bar-h"><span>Alternatives (REIT/commodities)</span><span style="color:var(--green)">2%</span></div><div class="bar"><div class="bar-f" style="width:2%;background:var(--amber)"></div></div></div>
+        <div style="font-size:11px;color:var(--hint);margin-top:6px">White marker = current level | Green bar = target</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- CONCENTRATION -->
+<div id="conc" class="pane">
+  <div class="card">
+    <div class="ct">Top 5 concentrated positions — 38% of portfolio ($1.8M)</div>
+    <div class="cs">Any single position above 5% is a concentration risk. You have five above 5%. In a tech downturn these move in lockstep — effective diversification is near zero among them.</div>
+    <div class="hld-row" style="color:var(--hint);font-weight:600;font-size:10px;text-transform:uppercase;letter-spacing:.06em;border-bottom:1px solid var(--border)">
+      <span>Ticker</span><span>Name</span><span style="text-align:right">Value</span><span style="text-align:right">% port</span><span style="text-align:right">Action</span>
+    </div>
+    <div class="hld-row"><span class="hld-tk">GOOG</span><span>Alphabet Inc</span><span class="hld-val">$469,806</span><span class="hld-pct" style="color:var(--red)">9.9%</span><span class="hld-act" style="color:var(--red)">Trim to 4%</span></div>
+    <div class="hld-row"><span class="hld-tk">META</span><span>Meta Platforms</span><span class="hld-val">$429,549</span><span class="hld-pct" style="color:var(--red)">9.1%</span><span class="hld-act" style="color:var(--red)">Trim to 4%</span></div>
+    <div class="hld-row"><span class="hld-tk">MSFT</span><span>Microsoft Corp</span><span class="hld-val">$355,410</span><span class="hld-pct" style="color:var(--red)">7.5%</span><span class="hld-act" style="color:var(--amber)">Trim to 4%</span></div>
+    <div class="hld-row"><span class="hld-tk">AMZN</span><span>Amazon.com</span><span class="hld-val">$302,619</span><span class="hld-pct" style="color:var(--red)">6.4%</span><span class="hld-act" style="color:var(--amber)">Trim to 4%</span></div>
+    <div class="hld-row"><span class="hld-tk">NVDA</span><span>NVIDIA Corp</span><span class="hld-val">$247,332</span><span class="hld-pct" style="color:var(--red)">5.2%</span><span class="hld-act" style="color:var(--amber)">Trim to 3%</span></div>
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-top:14px">
+      <div style="background:var(--red-bg);border-radius:8px;padding:12px">
+        <div style="font-size:12px;font-weight:600;color:var(--red);margin-bottom:6px">If you do nothing</div>
+        <div style="font-size:12px;color:var(--red);line-height:1.7">A 30% tech correction (2022-style) drops your portfolio by ~$700k. Combined with early retirement draws, this triggers the exact SRR scenario your buffer is designed to prevent — but with $1.8M concentrated in the epicenter of the drawdown.</div>
+      </div>
+      <div style="background:var(--green-bg);border-radius:8px;padding:12px">
+        <div style="font-size:12px;font-weight:600;color:var(--green);margin-bottom:6px">After diversification</div>
+        <div style="font-size:12px;color:var(--green);line-height:1.7">Same 30% tech correction with diversified portfolio: impact ≈ $350k (half the damage). Top 5 positions capped at 4% each = $190k each. Freed capital ($880k+) flows into buffer, international, and value ETFs — uncorrelated to tech.</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="ct">Fidelity Growth Commingled ($648k, 13.7%) — hidden concentration</div>
+    <div class="cs">This fund's top holdings are likely MSFT, AMZN, NVDA, META, AAPL, GOOG. You already own all of these individually. Estimated ~55% overlap with your individual tech stocks.</div>
+    <div class="ri"><span class="bdg bdg-a">Action</span><span class="ri-t">If this is in your 401k (appears to be from the Empower platform), you cannot sell it tax-free in a taxable account. However, at retirement when you roll over to an IRA, replace this with VTI or a blend of VTI + VXUS + VO. If you can switch within the 401k now, move half to a total market index and half to an international index fund.</span></div>
+  </div>
+
+  <div class="card">
+    <div class="ct">Trim schedule — tax-smart unwinding over 4 years</div>
+    <div class="cs">Sell $220k/yr from concentrated positions. In taxable: use highest-cost-basis lots. Offset with TLH from losers. In 401k: no tax friction — rebalance freely.</div>
+    <table class="cmp-tbl">
+      <thead><tr><th>Year</th><th>Trim from</th><th>Amount</th><th>Reinvest into</th><th>Tax strategy</th></tr></thead>
+      <tbody>
+        <tr><td>Year 1 (2026)</td><td>GOOG, META</td><td>~$220k</td><td>Buffer Tier 3 (2-yr CDs, T-Notes) + VXUS</td><td>Offset gains with TLH from losers in tail. Harvest BA, RIVN, ELAN, MOS, DOW losses.</td></tr>
+        <tr><td>Year 2 (2027)</td><td>MSFT, AMZN</td><td>~$220k</td><td>Buffer Tier 2 (1-yr CDs, T-Bills) + VTI</td><td>Bunch charitable deduction via DAF with appreciated shares. More TLH harvesting from tail.</td></tr>
+        <tr><td>Year 3 (2028)</td><td>NVDA, GOOG remainder</td><td>~$220k</td><td>Buffer Tier 1 (HYSA, MM) + SCHD + VO</td><td>If NV resident by now: no WA cap gains tax. If WA: stay under $1M household income (millionaire tax).</td></tr>
+        <tr><td>Year 4 (2029)</td><td>META remainder, AVGO</td><td>~$220k</td><td>Top off buffer + VIG + VSS</td><td>Final year of working or first year of retirement — time sales to lowest-income tax year.</td></tr>
+      </tbody>
+    </table>
+    <div class="ib ib-g">Total trimmed: ~$880k over 4 years. Top 5 drop from 38% to ~19% (still holding core positions, just right-sized). $570k flows into the 3-tier buffer. $310k into diversifying ETFs. All transitions are tax-coordinated with TLH and charitable giving.</div>
+  </div>
+</div>
+
+<!-- TARGET ALLOCATION -->
+<div id="target" class="pane">
+  <div class="card">
+    <div class="ct">Target portfolio allocation at retirement — 82% growth / 18% buffer</div>
+    <div class="cs">Designed for medium-to-high risk with structural protection via the 3-tier SRR buffer. ~$6.5M portfolio at age 55.</div>
+    <table class="cmp-tbl">
+      <thead><tr><th>Sleeve</th><th>Target %</th><th>Target $</th><th>Holdings</th><th>Risk</th></tr></thead>
+      <tbody>
+        <tr><td>US large cap core</td><td>30%</td><td>$1.95M</td><td>VTI (primary) + retained individual positions capped at 4% each</td><td style="color:var(--amber)">4/5</td></tr>
+        <tr><td>US large cap growth</td><td>10%</td><td>$650k</td><td>VUG or VOOG — replaces the fragmented growth positions</td><td style="color:var(--red)">5/5</td></tr>
+        <tr><td>International developed</td><td>12%</td><td>$780k</td><td>VXUS (primary) + VEA for developed only</td><td style="color:var(--amber)">4/5</td></tr>
+        <tr><td>International emerging</td><td>5%</td><td>$325k</td><td>VWO + VSS for small-cap intl</td><td style="color:var(--red)">5/5</td></tr>
+        <tr><td>US mid/small cap</td><td>5%</td><td>$325k</td><td>VO (mid) + IJR (small) + AVUV (small value factor)</td><td style="color:var(--red)">5/5</td></tr>
+        <tr><td>Dividend / value tilt</td><td>10%</td><td>$650k</td><td>SCHD (dividend growth) + VIG (dividend appreciation)</td><td style="color:#6EE7B7">3/5</td></tr>
+        <tr><td>REITs / alternatives</td><td>2%</td><td>$130k</td><td>FREL or VNQ + small commodity tilt</td><td style="color:var(--amber)">4/5</td></tr>
+        <tr><td style="color:var(--green)">Sector overlay (retained)</td><td>8%</td><td>$520k</td><td>Top 5 tech positions at max 4% each + AAPL, AVGO, XOM</td><td style="color:var(--red)">5/5</td></tr>
+        <tr style="background:var(--green-bg)"><td style="color:var(--green)">3-yr SRR buffer</td><td style="color:var(--green)">18%</td><td style="color:var(--green)">$1.17M</td><td style="color:var(--green)">Tier 1: HYSA/MM | Tier 2: 1-yr CDs/T-Bills | Tier 3: 2-yr T-Notes/munis</td><td style="color:var(--green)">1/5</td></tr>
+      </tbody>
+    </table>
+    <div class="ib ib-b">Weighted average risk: 3.7/5 (medium-high). Equity beta: ~0.85 (vs. 1.1 currently due to tech overweight). The buffer provides 3 years of floor spending ($120k × 3 = $360k minimum) with the rest covering discretionary draw. Max drawdown in a 2008-style crash: ~28% on growth sleeve vs. ~35% with current concentration.</div>
+  </div>
+
+  <div class="card">
+    <div class="ct">Account type optimization — which holdings in which accounts</div>
+    <div class="cs">Tax efficiency comes from placing high-turnover / income-generating assets in tax-sheltered accounts.</div>
+    <div class="ri"><span class="bdg bdg-g">401k / Trad IRA</span><span class="ri-t"><strong style="color:var(--text)">Bond funds, SCHD, VIG, REITs, FREL.</strong> Dividends and interest taxed at ordinary rates — shelter them. Roth conversions will move them tax-free over time. Rebalance freely (no tax friction). This is where your Stable Value ($206k) and target-date funds already live — correct placement.</span></div>
+    <div class="ri"><span class="bdg bdg-g">Roth 401k / Roth IRA</span><span class="ri-t"><strong style="color:var(--text)">Highest-growth assets: VUG, VOOG, VWO, VO, individual growth stocks (NVDA, AMZN).</strong> Growth compounds tax-free forever. These assets to heirs via Roth = 10-year tax-free distribution. Never put bonds in Roth — it wastes the tax-free growth advantage.</span></div>
+    <div class="ri"><span class="bdg bdg-g">Taxable brokerage</span><span class="ri-t"><strong style="color:var(--text)">VTI, VXUS, VEA, tax-managed individual stocks, muni bonds for buffer Tier 3.</strong> Index ETFs are tax-efficient (low turnover, no capital gains distributions). VXUS gets the Foreign Tax Credit (FTC) — only available in taxable. Individual stocks allow specific-lot TLH. Never hold REITs or high-dividend funds here.</span></div>
+    <div class="ri"><span class="bdg bdg-g">HSA</span><span class="ri-t"><strong style="color:var(--text)">Most aggressive growth: VUG or small-cap growth (AVUV).</strong> Triple tax advantage. Never touch until 65. Invest 100% in equities — this is 14+ years until Medicare. The $9,300/yr family contribution invested aggressively at 9% for 14 years = ~$300k+ tax-free for medical expenses in retirement.</span></div>
+  </div>
+</div>
+
+<!-- ETF PICKS -->
+<div id="etfs" class="pane">
+  <div class="card">
+    <div class="ct">Recommended core ETF portfolio — 5-point risk scale</div>
+    <div class="cs">Consolidate 140+ positions into 10–12 core ETFs + 5–8 retained conviction stocks. Each ETF selected for low expense ratio, tax efficiency, and non-overlapping coverage.</div>
+
+    <div class="etf-row" style="color:var(--hint);font-weight:600;font-size:10px;text-transform:uppercase;letter-spacing:.06em;border-bottom:1px solid var(--border)">
+      <span>Ticker</span><span>Role</span><span style="text-align:right">Exp ratio</span><span style="text-align:right">Risk</span>
+    </div>
+
+    <div style="font-size:11px;font-weight:600;color:var(--green);text-transform:uppercase;letter-spacing:.06em;padding:12px 0 6px">Risk 1/5 — Capital preservation (buffer)</div>
+    <div class="etf-row"><span class="etf-tk">SPAXX</span><span class="etf-nm">Fidelity Gov Money Market — Tier 1 buffer, immediate liquidity</span><span class="etf-er">0.42%</span><span class="etf-risk risk1">●●●●● 1</span></div>
+    <div class="etf-row"><span class="etf-tk">SGOV</span><span class="etf-nm">iShares 0-3 Month Treasury Bond — T-Bill ETF for Tier 2, more liquid than CDs</span><span class="etf-er">0.05%</span><span class="etf-risk risk1">●●●●● 1</span></div>
+    <div class="etf-row"><span class="etf-tk">SHY</span><span class="etf-nm">iShares 1-3 Year Treasury Bond — Tier 3 buffer, slightly longer duration</span><span class="etf-er">0.15%</span><span class="etf-risk risk1">●●●●● 1</span></div>
+
+    <div style="font-size:11px;font-weight:600;color:#6EE7B7;text-transform:uppercase;letter-spacing:.06em;padding:12px 0 6px">Risk 2/5 — Low volatility income</div>
+    <div class="etf-row"><span class="etf-tk">SCHD</span><span class="etf-nm">Schwab US Dividend Equity — high-quality dividend growers, 3.5% yield, low turnover</span><span class="etf-er">0.06%</span><span class="etf-risk risk2">●●●●○ 2</span></div>
+    <div class="etf-row"><span class="etf-tk">VIG</span><span class="etf-nm">Vanguard Dividend Appreciation — 10+ yr consecutive dividend raisers, quality tilt</span><span class="etf-er">0.05%</span><span class="etf-risk risk2">●●●●○ 2</span></div>
+
+    <div style="font-size:11px;font-weight:600;color:var(--amber);text-transform:uppercase;letter-spacing:.06em;padding:12px 0 6px">Risk 3/5 — Core equity (broad market)</div>
+    <div class="etf-row"><span class="etf-tk">VTI</span><span class="etf-nm">Vanguard Total Stock Market — entire US market, 4,000+ stocks, ultimate diversification</span><span class="etf-er">0.03%</span><span class="etf-risk risk3">●●●○○ 3</span></div>
+    <div class="etf-row"><span class="etf-tk">VXUS</span><span class="etf-nm">Vanguard Total Intl Stock — 8,000+ stocks, developed + emerging, FTC eligible in taxable</span><span class="etf-er">0.07%</span><span class="etf-risk risk3">●●●○○ 3</span></div>
+
+    <div style="font-size:11px;font-weight:600;color:#FB923C;text-transform:uppercase;letter-spacing:.06em;padding:12px 0 6px">Risk 4/5 — Growth tilt</div>
+    <div class="etf-row"><span class="etf-tk">VUG</span><span class="etf-nm">Vanguard Growth — large-cap growth, replaces fragmented growth fund overlap</span><span class="etf-er">0.04%</span><span class="etf-risk risk4">●●○○○ 4</span></div>
+    <div class="etf-row"><span class="etf-tk">VO</span><span class="etf-nm">Vanguard Mid-Cap — mid-cap blend, historically outperforms large over long periods</span><span class="etf-er">0.04%</span><span class="etf-risk risk4">●●○○○ 4</span></div>
+    <div class="etf-row"><span class="etf-tk">VNQ</span><span class="etf-nm">Vanguard Real Estate — REIT exposure, uncorrelated to tech, hold in 401k only (tax)</span><span class="etf-er">0.12%</span><span class="etf-risk risk4">●●○○○ 4</span></div>
+
+    <div style="font-size:11px;font-weight:600;color:var(--red);text-transform:uppercase;letter-spacing:.06em;padding:12px 0 6px">Risk 5/5 — High growth / high volatility</div>
+    <div class="etf-row"><span class="etf-tk">VWO</span><span class="etf-nm">Vanguard Emerging Markets — higher risk/reward, China/India/Brazil/Taiwan exposure</span><span class="etf-er">0.08%</span><span class="etf-risk risk5">●○○○○ 5</span></div>
+    <div class="etf-row"><span class="etf-tk">AVUV</span><span class="etf-nm">Avantis US Small Cap Value — factor-tilted small value, highest historical premium</span><span class="etf-er">0.25%</span><span class="etf-risk risk5">●○○○○ 5</span></div>
+    <div class="etf-row"><span class="etf-tk">VSS</span><span class="etf-nm">Vanguard FTSE All-World ex-US Small-Cap — international small-cap, uncorrelated</span><span class="etf-er">0.07%</span><span class="etf-risk risk5">●○○○○ 5</span></div>
+  </div>
+
+  <div class="card">
+    <div class="ct">Retained individual positions — conviction holds capped at 4% each</div>
+    <div class="cs">Keep 5–8 high-quality individual stocks you believe in — but cap each at 4% ($260k at $6.5M). These sit in the "sector overlay" sleeve.</div>
+    <table class="cmp-tbl">
+      <thead><tr><th>Ticker</th><th>Current</th><th>Cap at 4%</th><th>Trim</th><th>Rationale to keep</th></tr></thead>
+      <tbody>
+        <tr><td>GOOG</td><td>$470k (9.9%)</td><td>$260k</td><td style="color:var(--red)">−$210k</td><td>AI leadership, cloud, search moat</td></tr>
+        <tr><td>META</td><td>$430k (9.1%)</td><td>$260k</td><td style="color:var(--red)">−$170k</td><td>Social moat, AI infra, strong FCF</td></tr>
+        <tr><td>MSFT</td><td>$355k (7.5%)</td><td>$260k</td><td style="color:var(--red)">−$95k</td><td>Enterprise moat, Azure, AI copilot</td></tr>
+        <tr><td>AMZN</td><td>$303k (6.4%)</td><td>$260k</td><td style="color:var(--amber)">−$43k</td><td>AWS, e-commerce dominance</td></tr>
+        <tr><td>NVDA</td><td>$247k (5.2%)</td><td>$195k (3%)</td><td style="color:var(--amber)">−$52k</td><td>AI chips, but cyclical — cap lower</td></tr>
+        <tr><td>XOM</td><td>$26k (0.5%)</td><td>Keep as-is</td><td>—</td><td>Energy hedge, strong dividend, uncorrelated to tech</td></tr>
+        <tr><td>BRK.B</td><td>$17k (0.4%)</td><td>Build to 2%</td><td style="color:var(--green)">+$113k</td><td>Diversified conglomerate, cash-rich, zero-correlation</td></tr>
+      </tbody>
+    </table>
+    <div class="ib ib-b">Total retained: ~$1.26M in 7 positions (19% of portfolio). The other ~120 individual stocks get liquidated over 4 years and proceeds flow into core ETFs and the buffer. This transforms your portfolio from 140+ positions to ~20 holdings (12 ETFs + 7 stocks + buffer instruments).</div>
+  </div>
+</div>
+
+<!-- DIVERSIFICATION PLAN -->
+<div id="plan" class="pane">
+  <div class="card">
+    <div class="ct">4-year tax-smart diversification roadmap</div>
+    <div class="cs">Each phase coordinates selling with TLH, charitable giving, and buffer building. Target: 140+ positions → ~20 by retirement.</div>
+
+    <div class="phase" style="border-left-color:var(--cyan)">
+      <div class="phase-hd"><span class="phase-t">Phase 1: Q2–Q4 2026 — harvest losses + start trimming</span><span class="bdg bdg-b">~$250k moved</span></div>
+      <div class="phase-b">
+        <strong style="color:var(--text)">Sell (tax-loss harvest):</strong> Identify all positions currently at a loss — RIVN ($548, likely large loss), ELAN ($1,965), MOS ($1,264), DOW ($1,151), BA ($8,142 if below basis), BBWI ($475), WBD ($1,214), LULU ($1,322), AR ($1,367), MUR ($957). Harvest losses to build carryforward bank. Replace each with a non-identical ETF (VTI, VXUS, VO) to maintain market exposure.<br><br>
+        <strong style="color:var(--text)">Sell (overweight trim):</strong> Trim $120k from GOOG (sell highest-cost lots). Offset gains with harvested losses. Proceeds → Buffer Tier 3 (2-year CDs + T-Notes).<br><br>
+        <strong style="color:var(--text)">Charitable:</strong> Donate $50k of appreciated GOOG or META shares to DAF. Full FMV deduction at 35% bracket ($17.5k tax savings). Zero capital gains recognized.
+      </div>
+    </div>
+
+    <div class="phase" style="border-left-color:var(--green)">
+      <div class="phase-hd"><span class="phase-t">Phase 2: 2027 — accelerate consolidation</span><span class="bdg bdg-g">~$350k moved</span></div>
+      <div class="phase-b">
+        <strong style="color:var(--text)">Sell (tail cleanup):</strong> Liquidate all remaining positions under $3k (~50+ holdings). Combined value ~$100k. Small lots = minimal gains per position. Some will have losses for additional TLH. Proceeds → VTI + VXUS in taxable brokerage.<br><br>
+        <strong style="color:var(--text)">Sell (overweight trim):</strong> Trim $100k META + $80k MSFT. Offset with any remaining loss carryforward. Proceeds → Buffer Tier 2 (1-yr CDs, T-Bills) + SCHD in 401k.<br><br>
+        <strong style="color:var(--text)">401k rebalance:</strong> Switch Fidelity Growth Commingled ($648k) to 50% total market index + 30% international index + 20% stable value. Zero tax friction in 401k.
+      </div>
+    </div>
+
+    <div class="phase" style="border-left-color:var(--amber)">
+      <div class="phase-hd"><span class="phase-t">Phase 3: 2028 — buffer ramp + NV considerations</span><span class="bdg bdg-a">~$280k moved</span></div>
+      <div class="phase-b">
+        <strong style="color:var(--text)">Critical timing:</strong> WA millionaire tax effective Jan 1, 2028. If you establish NV residency, large gain realization is tax-free at the state level. This is the ideal year for the biggest trim if in NV.<br><br>
+        <strong style="color:var(--text)">Sell:</strong> Trim $150k NVDA + remaining GOOG to target. Liquidate mid-tier positions ($3k–$10k) that aren't conviction holds. Proceeds → Buffer Tier 1 (HYSA, MM) + VO + VIG.<br><br>
+        <strong style="color:var(--text)">Review:</strong> Portfolio should now be ~40 positions. Buffer at ~$700k of $861k target.
+      </div>
+    </div>
+
+    <div class="phase" style="border-left-color:var(--purple)">
+      <div class="phase-hd"><span class="phase-t">Phase 4: 2029 — final positioning for retirement</span><span class="bdg bdg-b">~$200k moved</span></div>
+      <div class="phase-b">
+        <strong style="color:var(--text)">Final trims:</strong> AMZN to $260k cap, META to $260k cap, AVGO to target. All remaining non-conviction individual positions sold.<br><br>
+        <strong style="color:var(--text)">Buffer completion:</strong> Top off 3-tier buffer to full $861k (inflation-adjusted). Final composition: ~$287k each in Tier 1/2/3.<br><br>
+        <strong style="color:var(--text)">Lock in:</strong> Portfolio is now ~20 positions. Set quarterly rebalancing calendar. Document the replenishment decision rules. Engage a fee-only CFP for annual review. You're ready.
+      </div>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="ct">Tax impact estimate over 4 years</div>
+    <div style="display:grid;grid-template-columns:1fr auto;gap:3px 20px;font-size:13px;line-height:2.1">
+      <span style="color:var(--muted)">Gross gains realized from trims</span><span style="font-weight:600;font-family:'JetBrains Mono',monospace;text-align:right">~$550–700k</span>
+      <span style="color:var(--muted)">Tax-loss harvesting offset</span><span style="font-weight:600;font-family:'JetBrains Mono',monospace;text-align:right;color:var(--green)">−$80–120k</span>
+      <span style="color:var(--muted)">DAF charitable contribution offset</span><span style="font-weight:600;font-family:'JetBrains Mono',monospace;text-align:right;color:var(--green)">−$50–100k</span>
+      <span style="color:var(--muted)">401k rebalancing (no tax)</span><span style="font-weight:600;font-family:'JetBrains Mono',monospace;text-align:right;color:var(--green)">−$200–300k</span>
+      <span style="color:var(--muted);border-top:1px solid var(--border);padding-top:4px">Net taxable gains</span><span style="font-weight:600;font-family:'JetBrains Mono',monospace;text-align:right;border-top:1px solid var(--border);padding-top:4px">~$130–280k</span>
+      <span style="color:var(--muted)">Estimated LTCG tax (15–20%)</span><span style="font-weight:600;font-family:'JetBrains Mono',monospace;text-align:right;color:var(--amber)">~$20–56k</span>
+      <span style="color:var(--muted)">Cost of NOT diversifying (30% tech crash on $1.8M)</span><span style="font-weight:600;font-family:'JetBrains Mono',monospace;text-align:right;color:var(--red)">−$540k</span>
+    </div>
+    <div class="ib ib-g">The tax cost of diversification ($20–56k over 4 years) is a fraction of the risk you're eliminating. Paying $40k in LTCG to avoid $540k in potential concentration losses is a 13:1 payoff ratio. This is insurance you're getting paid to buy.</div>
+  </div>
+</div>
+
+<!-- TAIL CLEANUP -->
+<div id="tail" class="pane">
+  <div class="card">
+    <div class="ct">Tail cleanup — 80+ positions under $5k to liquidate</div>
+    <div class="cs">These positions collectively represent ~$160k (3.4% of portfolio) but generate enormous tax reporting complexity and rebalancing friction. Most should be sold and reinvested into core ETFs.</div>
+    
+    <div class="ri"><span class="bdg bdg-r">Sell first — likely losses (TLH candidates)</span><span class="ri-t" style="font-family:'JetBrains Mono',monospace;font-size:11px;line-height:2">RIVN ($548) · BBWI ($475) · ELAN ($1,965) · MOS ($1,264) · DOW ($1,151) · MUR ($957) · AR ($1,367) · LULU ($1,322) · BA ($8,142) · CVS ($4,004) · WBD ($1,214) · PVH ($867) · KVUE ($871) · CMCSA ($1,438) · BMY ($4,229) · TDW ($1,681) · FQVLF ($2,396) · HUM ($902) · PCG ($932)</span></div>
+
+    <div class="ri"><span class="bdg bdg-a">Sell — too small to matter</span><span class="ri-t" style="font-family:'JetBrains Mono',monospace;font-size:11px;line-height:2">LPLA ($159) · BKNG ($212) · TTD ($275) · VV ($347) · CEG ($388) · Z ($504) · DVA ($496) · WCN ($464) · BKGFY ($468) · SBUX ($525) · UAL ($592) · DPZ ($689) · CHRW ($693) · FTAI ($698) · WING ($731) · BIIB ($715) · HCA ($741) · MSCI ($760) · FSLR ($762) · AXP ($762) · MSI ($793) · DIS ($797) · SFM ($822) · IBKR ($853) · BOX ($2,501) · APPF ($2,579)</span></div>
+
+    <div class="ri"><span class="bdg bdg-b">Review — small but decent companies</span><span class="ri-t" style="font-family:'JetBrains Mono',monospace;font-size:11px;line-height:2">COST ($3,519) · LLY ($3,468) · CRM ($4,300) · DDOG ($3,513) · ISRG ($2,747) · TMO ($2,012) · SPGI ($1,287) · MCO ($1,012) · UNH ($1,357) · LMT ($1,343) · NOC ($2,386) · TMUS ($1,178)<br><br><span style="color:var(--muted);font-family:'DM Sans',sans-serif">These are good companies but at 0.02–0.07% of your portfolio, they contribute nothing to returns. A $3k position would need to 10× just to move your portfolio 0.5%. Sell all and put proceeds into VTI — you'll still own these companies via the index.</span></span></div>
+  </div>
+
+  <div class="card">
+    <div class="ct">Overlapping index funds — consolidate to 2</div>
+    <div class="cs">You hold 7+ funds that all track roughly the same thing. Combined: ~$216k doing the job of one ETF.</div>
+    <table class="cmp-tbl">
+      <thead><tr><th>Current holding</th><th>Value</th><th>Overlap with</th><th>Action</th></tr></thead>
+      <tbody>
+        <tr><td>VOO</td><td>$39,133</td><td>VTI (99%)</td><td style="color:var(--red)">Sell → VTI</td></tr>
+        <tr><td>VFFSX</td><td>$28,636</td><td>VTI (99%)</td><td style="color:var(--red)">Sell → VTI</td></tr>
+        <tr><td>VOOG</td><td>$24,868</td><td>VUG (95%)</td><td style="color:var(--red)">Sell → VUG</td></tr>
+        <tr><td>SPYG</td><td>$3,642</td><td>VUG (97%)</td><td style="color:var(--red)">Sell → VUG</td></tr>
+        <tr><td>VV</td><td>$347</td><td>VTI (95%)</td><td style="color:var(--red)">Sell → VTI</td></tr>
+        <tr><td>QQQ</td><td>$39,669</td><td>VUG (85%)</td><td style="color:var(--amber)">Sell → VUG (higher tech overlap)</td></tr>
+        <tr style="background:var(--green-bg)"><td style="color:var(--green)">Keep: VTI</td><td style="color:var(--green)">$41,591</td><td>—</td><td style="color:var(--green)">Core US — build to $1.95M</td></tr>
+        <tr style="background:var(--green-bg)"><td style="color:var(--green)">Keep: VUG</td><td style="color:var(--green)">$38,234</td><td>—</td><td style="color:var(--green)">Growth tilt — build to $650k</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="card">
+    <div class="ct">End state — your portfolio in 4 years</div>
+    <div class="cs">From 140+ positions to ~20 holdings. Clean, manageable, tax-efficient, retirement-ready.</div>
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:14px;margin-top:8px">
+      <div style="background:var(--surface2);border-radius:8px;padding:14px">
+        <div style="font-size:11px;font-weight:600;color:var(--hint);text-transform:uppercase;letter-spacing:.06em;margin-bottom:10px">Core ETFs (12)</div>
+        <div style="font-size:12px;color:var(--muted);line-height:2.2;font-family:'JetBrains Mono',monospace">
+          VTI — US total market<br>VUG — US growth<br>VXUS — International<br>VWO — Emerging markets<br>
+          VO — Mid-cap<br>AVUV — Small value<br>VSS — Intl small-cap<br>SCHD — Dividend growth<br>
+          VIG — Dividend appreciation<br>VNQ — REITs (401k)<br>SGOV — T-Bill buffer<br>SHY — Short-term Treasury
+        </div>
+      </div>
+      <div style="background:var(--surface2);border-radius:8px;padding:14px">
+        <div style="font-size:11px;font-weight:600;color:var(--hint);text-transform:uppercase;letter-spacing:.06em;margin-bottom:10px">Conviction stocks (7) + buffer</div>
+        <div style="font-size:12px;color:var(--muted);line-height:2.2;font-family:'JetBrains Mono',monospace">
+          GOOG — 4% cap<br>META — 4% cap<br>MSFT — 4% cap<br>AMZN — 4% cap<br>
+          NVDA — 3% cap<br>XOM — hold<br>BRK.B — build to 2%<br><br>
+          <span style="color:var(--green)">Tier 1: SPAXX/HYSA</span><br>
+          <span style="color:var(--green)">Tier 2: CDs + SGOV</span><br>
+          <span style="color:var(--green)">Tier 3: SHY + Munis</span>
+        </div>
+      </div>
+    </div>
+    <div class="ib ib-g" style="margin-top:14px">This portfolio is designed to run on autopilot: quarterly rebalancing takes 30 minutes, tax reporting fits on one page, and every position has a clear role. No more tracking 140+ tickers, managing 140+ 1099 lines, or wondering what that $275 TTD position is doing for your retirement.</div>
+  </div>
+</div>
+
+</div>
+
+<script>
+function showTab(id, btn) {
+  var panes = document.querySelectorAll('.pane');
+  var btns = document.querySelectorAll('.nb');
+  for (var i = 0; i < panes.length; i++) panes[i].classList.remove('on');
+  for (var i = 0; i < btns.length; i++) btns[i].classList.remove('on');
+  document.getElementById(id).classList.add('on');
+  btn.classList.add('on');
+}
+</script>
+</body>
+</html>

--- a/retirement_master_plan_2.html
+++ b/retirement_master_plan_2.html
@@ -1,0 +1,870 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Retirement Master Plan — Age 51 | Married Couple | WA State</title>
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{
+  --bg:#F0F2F5;--surface:#FFFFFF;--surface2:#F7F9FB;--border:#E2E6EA;--border2:#CBD5E1;
+  --text:#0F172A;--muted:#64748B;--hint:#94A3B8;
+  --navy:#1E3A5F;--blue:#2563EB;--green:#059669;--amber:#D97706;--red:#DC2626;--purple:#7C3AED;
+  --green-bg:#ECFDF5;--green-t:#065F46;
+  --amber-bg:#FFFBEB;--amber-t:#92400E;
+  --red-bg:#FEF2F2;--red-t:#991B1B;
+  --blue-bg:#EFF6FF;--blue-t:#1E40AF;
+  --purple-bg:#F3F0FF;--purple-t:#4C1D95;
+}
+body{font-family:-apple-system,'Helvetica Neue',Arial,sans-serif;background:var(--bg);color:var(--text);font-size:14px;line-height:1.6;min-height:100vh}
+.hdr{background:var(--navy);color:white;padding:18px 28px;display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:12px}
+.hdr-l h1{font-size:17px;font-weight:600}
+.hdr-l p{font-size:11px;opacity:.6;margin-top:2px}
+.hdr-r{display:flex;gap:24px}
+.hs{text-align:right}.hs-v{font-size:19px;font-weight:600}.hs-l{font-size:11px;opacity:.55}
+.nav{background:var(--surface);border-bottom:1px solid var(--border);padding:0 24px;display:flex;overflow-x:auto}
+.nb{padding:13px 15px;border:none;background:transparent;color:var(--muted);cursor:pointer;font-size:13px;font-weight:500;border-bottom:2px solid transparent;white-space:nowrap;font-family:inherit;transition:color .15s}
+.nb:hover{color:var(--text)}.nb.on{color:var(--navy);border-bottom-color:var(--navy)}
+.main{padding:22px 28px;max-width:940px;margin:0 auto}
+.pane{display:none}.pane.on{display:block}
+.g4{display:grid;grid-template-columns:repeat(auto-fit,minmax(155px,1fr));gap:10px;margin-bottom:14px}
+.sc{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:13px 15px}
+.sc-l{font-size:11px;color:var(--muted);margin-bottom:3px;text-transform:uppercase;letter-spacing:.04em}
+.sc-v{font-size:20px;font-weight:600}
+.g{color:var(--green)}.r{color:var(--red)}.b{color:var(--blue)}.a{color:var(--amber)}
+.card{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:17px 19px;margin-bottom:14px}
+.ct{font-size:14px;font-weight:600;margin-bottom:3px}
+.cs{font-size:12px;color:var(--muted);margin-bottom:12px}
+.bdg{display:inline-block;font-size:11px;font-weight:500;padding:2px 8px;border-radius:20px;flex-shrink:0}
+.bdg-r{background:var(--red-bg);color:var(--red-t)}
+.bdg-a{background:var(--amber-bg);color:var(--amber-t)}
+.bdg-b{background:var(--blue-bg);color:var(--blue-t)}
+.bdg-g{background:var(--green-bg);color:var(--green-t)}
+.bdg-p{background:var(--purple-bg);color:var(--purple-t)}
+.ri{display:flex;align-items:flex-start;gap:11px;padding:9px 0;border-bottom:1px solid var(--border)}
+.ri:last-child{border-bottom:none}
+.ri-t{flex:1;font-size:13px;color:var(--muted);line-height:1.6}
+.pb-w{margin-bottom:11px}
+.pb-h{display:flex;justify-content:space-between;font-size:13px;margin-bottom:4px}
+.pb{height:6px;background:var(--border);border-radius:3px;overflow:hidden}
+.pb-f{height:100%;border-radius:3px}
+.tier{border:1px solid var(--border);border-left:3px solid;border-radius:10px;border-top-left-radius:0;border-bottom-left-radius:0;padding:13px 15px;margin-bottom:10px}
+.tier-hd{display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:7px}
+.tier-t{font-size:13px;font-weight:600}.tier-st{font-size:11px;color:var(--muted);margin-top:1px}
+.tier-amt{text-align:right;flex-shrink:0;margin-left:10px}
+.tier-v{font-size:15px;font-weight:600}.tier-y{font-size:11px}
+.tier-b{font-size:12px;color:var(--muted);line-height:1.7}
+.ib{border-radius:8px;padding:10px 13px;font-size:12px;line-height:1.7;margin-top:10px}
+.ib-g{background:var(--green-bg);color:var(--green-t)}
+.ib-a{background:var(--amber-bg);color:var(--amber-t)}
+.ib-r{background:var(--red-bg);color:var(--red-t)}
+.ib-b{background:var(--blue-bg);color:var(--blue-t)}
+.ib-p{background:var(--purple-bg);color:var(--purple-t)}
+.sbg{background:var(--surface2);border-radius:10px;padding:13px 15px;margin-top:12px}
+.sbg-t{font-size:13px;font-weight:600;margin-bottom:9px}
+.cw{position:relative;width:100%;height:300px;margin:10px 0}
+.cw-sm{height:240px}
+.sc-btns{display:flex;gap:6px;flex-wrap:wrap;margin-bottom:11px}
+.sc-btn{padding:5px 11px;border:1px solid var(--border);background:var(--surface);color:var(--muted);cursor:pointer;font-size:12px;font-weight:500;border-radius:6px;transition:all .15s;font-family:inherit}
+.sc-btn:hover{border-color:var(--navy);color:var(--navy)}
+.sc-btn.on{background:var(--navy);color:white;border-color:var(--navy)}
+.cl{display:flex;flex-wrap:wrap;gap:14px;font-size:12px;color:var(--muted);margin-top:8px}
+.cl-i{display:flex;align-items:center;gap:5px}
+.cl-d{width:12px;height:3px;border-radius:2px;display:inline-block}
+.phase{border-left:3px solid;padding:12px 14px;border-radius:0 8px 8px 0;margin-bottom:10px;background:var(--surface2)}
+.phase-hd{display:flex;justify-content:space-between;align-items:center;margin-bottom:6px;flex-wrap:wrap;gap:6px}
+.phase-t{font-size:13px;font-weight:600}
+.phase-b{font-size:12px;color:var(--muted);line-height:1.7}
+.it{display:grid;grid-template-columns:1fr 1fr;gap:3px 20px;font-size:12px;line-height:2}
+.it-k{color:var(--blue-t)}.it-v{font-weight:600;text-align:right;color:var(--blue-t)}
+.kv{display:grid;grid-template-columns:1fr auto;gap:3px 20px;font-size:13px;line-height:2.1}
+.kv-k{color:var(--muted)}.kv-v{font-weight:600;text-align:right}
+.kv-sep{border-top:1px solid var(--border);padding-top:4px;color:var(--text)}
+.kv-sep-g{border-top:1px solid var(--border);padding-top:4px;color:var(--green);font-weight:600;text-align:right}
+.mort-g{display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-bottom:12px}
+.mort-c{background:var(--surface2);border-radius:8px;padding:12px}
+.mort-ct{font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:.04em;font-weight:600;margin-bottom:6px}
+.mort-cb{font-size:12px;color:var(--muted);line-height:1.6}
+.tlh{padding:10px 0 10px 13px;border-left:3px solid var(--border2);margin-bottom:9px}
+.tlh-t{font-size:13px;font-weight:600;margin-bottom:3px}
+.tlh-b{font-size:12px;color:var(--muted);line-height:1.7}
+.benef-g{display:grid;grid-template-columns:1fr 1fr;gap:10px}
+.benef-c{background:var(--surface2);border-radius:8px;padding:12px}
+.benef-ct{font-size:12px;font-weight:600;margin-bottom:4px}
+.benef-cb{font-size:11px;color:var(--muted);line-height:1.6}
+.tl-item{display:flex;gap:14px;padding-bottom:24px}
+.tl-col{display:flex;flex-direction:column;align-items:center}
+.tl-dot{width:34px;height:34px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:600;flex-shrink:0}
+.tl-line{width:1px;flex:1;background:var(--border);margin-top:5px}
+.tl-t{font-size:13px;font-weight:600;margin-bottom:5px;padding-top:5px}
+.tl-b{font-size:12px;color:var(--muted);line-height:1.8}
+.cmp-tbl{width:100%;border-collapse:collapse;font-size:12px;margin-top:10px}
+.cmp-tbl th{text-align:left;padding:8px 10px;background:var(--surface2);font-weight:600;font-size:11px;text-transform:uppercase;letter-spacing:.04em;color:var(--muted);border-bottom:1px solid var(--border)}
+.cmp-tbl td{padding:8px 10px;border-bottom:1px solid var(--border);color:var(--muted);vertical-align:top;line-height:1.5}
+.cmp-tbl tr:last-child td{border-bottom:none}
+.cmp-tbl td:first-child{font-weight:600;color:var(--text);white-space:nowrap}
+.seg{position:absolute;bottom:0;height:48%;transition:width .3s,left .3s}
+.bzone{position:absolute;top:0;height:100%}
+.blbl{position:absolute;top:5px;font-size:10px;font-weight:500;padding:0 5px}
+.rmd-krow{display:flex;justify-content:space-between;padding:7px 0;border-bottom:0.5px solid var(--border);font-size:13px}
+.rmd-krow:last-child{border-bottom:none}
+@media(max-width:600px){
+  .hdr-r{gap:14px}.hs-v{font-size:15px}
+  .g4{grid-template-columns:1fr 1fr}
+  .mort-g,.benef-g,.it{grid-template-columns:1fr}
+  .main{padding:16px}
+  .cmp-tbl{font-size:11px}
+}
+</style>
+</head>
+<body>
+
+<div class="hdr">
+  <div class="hdr-l">
+    <h1>Retirement Master Plan</h1>
+    <p>Married couple &middot; Age 51 &middot; WA State &middot; Retiring at 55 &middot; $250k/yr spending target</p>
+  </div>
+  <div class="hdr-r">
+    <div class="hs"><div class="hs-v">$4.5M</div><div class="hs-l">Current portfolio</div></div>
+    <div class="hs"><div class="hs-v" style="color:#6EE7B7">$6.5M</div><div class="hs-l">Target at 55</div></div>
+    <div class="hs"><div class="hs-v">Age 70</div><div class="hs-l">Claim SS</div></div>
+  </div>
+</div>
+
+<div class="nav">
+  <button class="nb on" onclick="showTab('ov',this)">Overview</button>
+  <button class="nb" onclick="showTab('buf',this)">3-yr buffer</button>
+  <button class="nb" onclick="showTab('proj',this)">Projection</button>
+  <button class="nb" onclick="showTab('roth',this)">Roth + SS</button>
+  <button class="nb" onclick="showTab('tax',this)">Tax strategy</button>
+  <button class="nb" onclick="showTab('est',this)">Estate plan</button>
+  <button class="nb" onclick="showTab('rmd',this)">RMD calculator</button>
+  <button class="nb" onclick="showTab('tl',this)">Timeline</button>
+</div>
+
+<div class="main">
+
+<!-- OVERVIEW -->
+<div id="ov" class="pane on">
+  <div class="g4">
+    <div class="sc"><div class="sc-l">Current portfolio</div><div class="sc-v">$4.5M</div></div>
+    <div class="sc"><div class="sc-l">Target at age 55</div><div class="sc-v b">$6.5M</div></div>
+    <div class="sc"><div class="sc-l">Projected at age 55</div><div class="sc-v g">~$6.52M</div></div>
+    <div class="sc"><div class="sc-l">3-yr buffer needed</div><div class="sc-v">$861k</div></div>
+    <div class="sc"><div class="sc-l">Spend at retirement</div><div class="sc-v">$287k/yr</div></div>
+    <div class="sc"><div class="sc-l">Spend at age 70</div><div class="sc-v">$481k/yr</div></div>
+    <div class="sc"><div class="sc-l">SS claim (both spouses)</div><div class="sc-v g">Age 70</div></div>
+    <div class="sc"><div class="sc-l">WA new tax risk (2028+)</div><div class="sc-v r">9.9%</div></div>
+  </div>
+
+  <div class="card">
+    <div class="ct">Readiness scorecard</div>
+    <div style="margin-top:6px">
+      <div class="pb-w"><div class="pb-h"><span>Portfolio vs. target</span><span class="g" style="font-weight:600">On track — 99%</span></div><div class="pb"><div class="pb-f" style="width:99%;background:var(--green)"></div></div></div>
+      <div class="pb-w"><div class="pb-h"><span>SRR buffer plan</span><span class="b" style="font-weight:600">Defined — implement now</span></div><div class="pb"><div class="pb-f" style="width:70%;background:var(--blue)"></div></div></div>
+      <div class="pb-w"><div class="pb-h"><span>Roth conversion plan</span><span class="a" style="font-weight:600">Needs work</span></div><div class="pb"><div class="pb-f" style="width:25%;background:var(--amber)"></div></div></div>
+      <div class="pb-w"><div class="pb-h"><span>LTC coverage</span><span class="a" style="font-weight:600">Undercovered</span></div><div class="pb"><div class="pb-f" style="width:35%;background:var(--amber)"></div></div></div>
+      <div class="pb-w"><div class="pb-h"><span>WA millionaire tax + NV residency plan</span><span class="r" style="font-weight:600">Critical — plan before 2028</span></div><div class="pb"><div class="pb-f" style="width:15%;background:var(--red)"></div></div></div>
+      <div class="pb-w" style="margin-bottom:0"><div class="pb-h"><span>Estate / trust setup</span><span class="r" style="font-weight:600">Critical gap — urgent</span></div><div class="pb"><div class="pb-f" style="width:12%;background:var(--red)"></div></div></div>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="ct">Priority action items</div>
+    <div class="ri"><span class="bdg bdg-r">Urgent</span><span class="ri-t">Draft estate plan — community property trust, wills, POA, healthcare directives for both spouses. OBBBA permanently sets federal exemption at $15M/$30M MFJ — federal risk eliminated, but WA state estate tax ($3M exclusion, top rate 20%) still applies. Hire WA estate attorney this quarter.</span></div>
+    <div class="ri"><span class="bdg bdg-r">Urgent</span><span class="ri-t">Start Roth conversions this tax year. Fill to top of 22% MFJ bracket ($201,050). Without conversions, future RMDs at 73 will push you into 22–24% brackets plus trigger IRMAA and potentially WA's 9.9% millionaire tax on income over $1M/household. Coordinate with spouse's income.</span></div>
+    <div class="ri"><span class="bdg bdg-r">Urgent</span><span class="ri-t">Evaluate NV residency before WA 9.9% millionaire tax takes effect Jan 1, 2028. At your income level, this could save $50–150k+/yr in state taxes alone. Begin establishing NV domicile well before the effective date — WA will scrutinize residency claims aggressively.</span></div>
+    <div class="ri"><span class="bdg bdg-a">High</span><span class="ri-t">Open a Donor-Advised Fund (Fidelity Charitable or Schwab Charitable). Contribute appreciated stock at 35% MFJ deduction now. WA's millionaire tax allows $100k charitable deduction against state taxable income — potential double benefit at federal + state level.</span></div>
+    <div class="ri"><span class="bdg bdg-a">High</span><span class="ri-t">Upgrade LTC to hybrid life/LTC policies for both spouses at 51. Premiums rise 5–8%/yr and health changes can disqualify. Waiting until 55 costs 20–30% more. Get quotes for both immediately.</span></div>
+    <div class="ri"><span class="bdg bdg-b">Medium</span><span class="ri-t">Keep the 2.5% mortgage — do NOT pay off. At 2.5% fixed vs. 3.5% inflation, you're earning 1%/yr real return on borrowed money. Use SALT deduction (now $40k through 2029 under OBBBA, but phased down for MFJ >$500k) and itemize with mortgage interest + property tax + charitable. See Tax tab for full strategy.</span></div>
+    <div class="ri"><span class="bdg bdg-b">Medium</span><span class="ri-t">Max HSA as family ($8,300 + $1k catch-up = $9,300). Invest aggressively. After 65, both spouses use tax-free for Medicare premiums and medical — completely invisible to IRMAA. Name each other as HSA beneficiary (spouse inherits as HSA tax-free).</span></div>
+  </div>
+</div>
+
+<!-- BUFFER -->
+<div id="buf" class="pane">
+  <div class="card">
+    <div class="ct">3-tier SRR buffer ladder — funded at retirement (age 55)</div>
+    <div class="cs">Total: $861k &nbsp;|&nbsp; Average yield: ~4.8% &nbsp;|&nbsp; Annual interest: ~$41k — meaningfully offsets yield drag</div>
+
+    <div class="tier" style="border-left-color:var(--green)">
+      <div class="tier-hd">
+        <div><div class="tier-t">Tier 1 — Year 1 spending (immediate access)</div><div class="tier-st">HYSA + Money Market Fund</div></div>
+        <div class="tier-amt"><div class="tier-v">$287k</div><div class="tier-y g">4.5–5.0%</div></div>
+      </div>
+      <div class="tier-b">Fidelity FZFXX, Vanguard VMFXX, or HYSA (SoFi, Marcus). Keep 3 months in joint checking, 9 months in money market. Replenish from Tier 2 monthly. Never let this drop below 3 months of expenses.</div>
+    </div>
+
+    <div class="tier" style="border-left-color:var(--blue)">
+      <div class="tier-hd">
+        <div><div class="tier-t">Tier 2 — Year 2 spending</div><div class="tier-st">12-month CD ladder + 1-yr Treasury Bills</div></div>
+        <div class="tier-amt"><div class="tier-v">$287k</div><div class="tier-y b">4.7–5.0%</div></div>
+      </div>
+      <div class="tier-b">Split $71k CDs across 4 banks quarterly (FDIC $250k/depositor/bank — joint accounts double to $500k). Rolling 3-month maturity replenishes Tier 1 automatically. T-Bills (4, 8, 13-week) add flexibility. Entire tier rolls into Tier 1 every 12 months.</div>
+    </div>
+
+    <div class="tier" style="border-left-color:var(--purple)">
+      <div class="tier-hd">
+        <div><div class="tier-t">Tier 3 — Year 3 spending</div><div class="tier-st">2-yr Treasuries + WA Municipal Bonds + 24-mo CDs</div></div>
+        <div class="tier-amt"><div class="tier-v">$287k</div><div class="tier-y" style="color:var(--purple)">4.5–4.8%</div></div>
+      </div>
+      <div class="tier-b">WA munis: federally tax-exempt. 2-yr Treasury notes for safety. BIL or SHY ETFs for liquid flex tranche. At 22% MFJ retirement bracket: 3.5% muni = 4.49% taxable equivalent. Rolls into Tier 2 annually. Note: if you relocate to NV, WA munis remain federally tax-exempt — no change needed.</div>
+    </div>
+
+    <div class="sbg">
+      <div class="sbg-t">Quarterly replenishment decision rules</div>
+      <div style="display:flex;flex-direction:column;gap:9px">
+        <div style="display:flex;gap:9px;align-items:flex-start"><span class="bdg bdg-g" style="margin-top:1px">Market up</span><span class="tier-b">Sell from growth portfolio. Prioritize rebalancing first — trim overweight positions. In taxable: sell highest-cost-basis lots to minimize gains. In 401k/IRA: no tax friction. Target quarterly cadence, not monthly.</span></div>
+        <div style="display:flex;gap:9px;align-items:flex-start"><span class="bdg bdg-r" style="margin-top:1px">Market down</span><span class="tier-b">Do NOT sell equities. Draw Tier 1 only. Harvest tax losses in growth portfolio (TLH). Do not replenish buffer until market recovers 10%+ from its low. You have 3 years — use every day of it.</span></div>
+        <div style="display:flex;gap:9px;align-items:flex-start"><span class="bdg bdg-b" style="margin-top:1px">Age 70+</span><span class="tier-b">Combined SS income for both spouses (~$200k+ nominal) auto-replenishes ~40–50% of buffer annually. RMDs also fund Tier 1. Sell growth only for the net shortfall.</span></div>
+        <div style="display:flex;gap:9px;align-items:flex-start"><span class="bdg bdg-a" style="margin-top:1px">Flex lever</span><span class="tier-b">In a severe down-market year: reduce discretionary from $130k to $50–75k. This extends the buffer from 3 to 4.5–5 effective years — nearly eliminating sequence risk without selling a single equity position.</span></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="ct">Buffer inflation adjustment — annual target schedule</div>
+    <div class="cs">Replenish Tier 1 to the current year's inflation-adjusted need, not just last year's level</div>
+    <div class="g4">
+      <div class="sc"><div class="sc-l">Age 55</div><div class="sc-v" style="font-size:17px">$287k/yr</div><div style="font-size:11px;color:var(--muted);margin-top:2px">Buffer total: $861k</div></div>
+      <div class="sc"><div class="sc-l">Age 60</div><div class="sc-v" style="font-size:17px">$341k/yr</div><div style="font-size:11px;color:var(--muted);margin-top:2px">Buffer total: $1.02M</div></div>
+      <div class="sc"><div class="sc-l">Age 65</div><div class="sc-v" style="font-size:17px">$405k/yr</div><div style="font-size:11px;color:var(--muted);margin-top:2px">Buffer total: $1.22M</div></div>
+      <div class="sc"><div class="sc-l">Age 70</div><div class="sc-v" style="font-size:17px">$481k/yr</div><div style="font-size:11px;color:var(--green);margin-top:2px">Net after SS: ~$262k</div></div>
+    </div>
+    <div class="ib ib-b">At age 70, combined SS income for both spouses (~$219k nominal at 3.5% inflation, assuming both claim at 70) reduces the net portfolio draw from $481k to ~$262k/yr — a 45% reduction that significantly extends longevity and eases replenishment pressure.</div>
+  </div>
+</div>
+
+<!-- PROJECTION -->
+<div id="proj" class="pane">
+  <div class="g4">
+    <div class="sc"><div class="sc-l">Starting portfolio (age 55)</div><div class="sc-v">$6.52M</div></div>
+    <div class="sc"><div class="sc-l">Base case — age 70</div><div class="sc-v b" id="v70">—</div></div>
+    <div class="sc"><div class="sc-l">Base case — age 85</div><div class="sc-v g" id="v85">—</div></div>
+    <div class="sc"><div class="sc-l">Stress case — age 85</div><div class="sc-v a" id="v85s">—</div></div>
+  </div>
+
+  <div class="card">
+    <div class="ct">Portfolio projection — age 55 to 90 (married couple)</div>
+    <div class="cs">Both spouses' SS added at age 70 | RMDs begin at age 73 | All values nominal ($M)</div>
+    <div class="sc-btns">
+      <button class="sc-btn on" onclick="switchScen('base',this)">Base (7%, 3.5% inf)</button>
+      <button class="sc-btn" onclick="switchScen('stress',this)">Stress (5%, 4% inf)</button>
+      <button class="sc-btn" onclick="switchScen('bull',this)">Bull (9%, 3.5% inf)</button>
+      <button class="sc-btn" onclick="switchScen('all',this)">All 3 scenarios</button>
+    </div>
+    <div class="cw">
+      <canvas id="projChart" role="img" aria-label="Portfolio projection from age 55 to 90 for married couple.">Portfolio projection chart comparing three scenarios.</canvas>
+    </div>
+    <div class="cl">
+      <span class="cl-i"><span class="cl-d" style="background:var(--green)"></span>Bull (9%)</span>
+      <span class="cl-i"><span class="cl-d" style="background:var(--blue)"></span>Base (7%)</span>
+      <span class="cl-i"><span class="cl-d" style="background:var(--amber);border-top:2px dashed var(--amber);height:0"></span>Stress (5%, 4% inflation)</span>
+      <span style="font-size:11px">Combined SS at age 70 | Stress line is dashed</span>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="ct">Savings roadmap to $6.5M by age 55</div>
+    <div class="cs">At current savings pace you are on track — minimal additional effort required</div>
+    <div class="kv">
+      <span class="kv-k">$4.5M current at 7% for 4 years</span><span class="kv-v">$5.90M</span>
+      <span class="kv-k">401k + catch-up (4 yrs × $30.5k, compounded)</span><span class="kv-v">+$135k</span>
+      <span class="kv-k">HSA family max (4 yrs × $9.3k, compounded)</span><span class="kv-v">+$40k</span>
+      <span class="kv-k">Taxable savings (~$100k/yr, compounded)</span><span class="kv-v">+$449k</span>
+      <span class="kv-k kv-sep" style="font-weight:600;color:var(--text)">Projected at retirement (age 55)</span><span class="kv-sep-g">$6.52M</span>
+      <span class="kv-k">Target needed (3.8% effective SWR + SS at 70)</span><span class="kv-v b">$6.50M</span>
+    </div>
+    <div class="ib ib-g">On track as a couple. If spouse also works and contributes to a 401k, the cushion grows further. With the 2.5% mortgage kept in place (not paid off), you retain ~$85k/yr in portfolio assets earning 7% instead of extinguishing cheap debt.</div>
+  </div>
+</div>
+
+<!-- ROTH + SS -->
+<div id="roth" class="pane">
+  <div class="card">
+    <div class="ct">Social Security claiming strategy — both spouses claim at age 70</div>
+    <div class="cs">Break-even vs. 65: ~age 80.7 &nbsp;|&nbsp; vs. 68: ~age 82.8 &nbsp;|&nbsp; Portfolio sustains the 15-year wait for both. Combined SS at 70 provides powerful buffer replenishment.</div>
+    <div class="cw cw-sm">
+      <canvas id="ssChart" role="img" aria-label="Cumulative lifetime SS benefits comparing claim ages 65, 68, and 70.">Cumulative Social Security benefits by claim age.</canvas>
+    </div>
+    <div class="cl">
+      <span class="cl-i"><span class="cl-d" style="background:var(--red)"></span>Age 65 ($3,547/mo)</span>
+      <span class="cl-i"><span class="cl-d" style="background:var(--amber)"></span>Age 68 ($4,502/mo)</span>
+      <span class="cl-i"><span class="cl-d" style="background:var(--green)"></span>Age 70 ($5,203/mo) — recommended</span>
+    </div>
+    <div class="ib ib-g"><strong>Both spouses claim at 70.</strong> Combined monthly: ~$10,400+/mo (if both have similar earnings). Combined annual: ~$125k+ (nominal), growing to ~$219k+ by age 70 after COLA. Spousal strategy: if one spouse has lower earnings, their spousal benefit at 70 = 50% of higher earner's PIA. Both delaying maximizes survivor benefit — critical for the surviving spouse's financial security. 85% of combined SS is taxable at your income level.</div>
+  </div>
+
+  <div class="card">
+    <div class="ct">Roth conversion master plan — ages 55 to 72 (MFJ brackets)</div>
+    <div class="cs">Goal: convert traditional 401k before RMDs at 73 force large taxable distributions. MFJ brackets give you 2× the room per bracket vs. single filers.</div>
+
+    <div class="phase" style="border-left-color:var(--green)">
+      <div class="phase-hd"><span class="phase-t">Phase 1: Ages 55–63 — prime window</span><span class="bdg bdg-g">Convert $200–350k/yr MFJ</span></div>
+      <div class="phase-b">No W-2 income in retirement. Fill to top of 22% MFJ bracket ($201,050). With $0 other income: $200k conversion ≈ $30–40k tax at ~17% effective rate. MFJ doubles bracket width vs. single — major advantage. Always pay conversion tax from taxable brokerage. Over 9 years: $1.8–3.1M converted tax-efficiently.</div>
+    </div>
+
+    <div class="phase" style="border-left-color:var(--amber)">
+      <div class="phase-hd"><span class="phase-t">Phase 2: Ages 63–65 — IRMAA control</span><span class="bdg bdg-a">Pause or $100–150k</span></div>
+      <div class="phase-b">IRMAA uses income 2 years prior. Age 63 income = age 65 Medicare premium. Target MAGI below $206k MFJ. Roth conversions count as MAGI — reduce if necessary. Use DAF contributions to offset. File SSA-44 for both spouses at 65 citing retirement as a life-changing income event.</div>
+    </div>
+
+    <div class="phase" style="border-left-color:var(--blue)">
+      <div class="phase-hd"><span class="phase-t">Phase 3: Ages 66–72 — moderate conversions</span><span class="bdg bdg-b">$100–150k/yr</span></div>
+      <div class="phase-b">Both spouses on Medicare. Balance IRMAA tier cost vs. long-term Roth benefit. SS income at 70 adds to MAGI — factor in carefully. Use QCDs for charitable giving (up to $105k/yr per spouse from IRA — NOT MAGI). Target: reduce combined traditional 401k/IRA to ≤$500k before age 73.</div>
+    </div>
+
+    <div class="sbg" style="background:var(--blue-bg)">
+      <div class="sbg-t" style="color:var(--blue-t)">18-year conversion impact (MFJ)</div>
+      <div class="it">
+        <span class="it-k">Total converted (estimate)</span><span class="it-v">~$2.5–3.5M</span>
+        <span class="it-k">Tax paid on conversions @ ~17–22%</span><span class="it-v">~$425–770k</span>
+        <span class="it-k">Tax if NOT converted (RMDs @ 24%+)</span><span class="it-v">~$600–840k</span>
+        <span class="it-k">Lifetime tax savings</span><span class="it-v">~$175–300k</span>
+        <span class="it-k">Estate benefit — Roth to heirs (tax-free)</span><span class="it-v">$2.5M+</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- TAX STRATEGY -->
+<div id="tax" class="pane">
+  <div class="card">
+    <div class="ct">IRMAA avoidance — Medicare Part B/D surcharge mitigation (both spouses)</div>
+    <div class="cs">Without planning, drawing $250k from traditional 401k triggers IRMAA Tier 3+ (+$384/mo per person, 2024). Goal: keep combined MAGI below $206k MFJ.</div>
+    <div class="ri"><span class="bdg bdg-g">Roth draws</span><span class="ri-t">Not counted in MAGI. The primary lever. Draw from Roth IRA/401k for spending in Medicare years. This is why the Roth conversion plan ages 55–63 using MFJ brackets is critical.</span></div>
+    <div class="ri"><span class="bdg bdg-g">HSA draws</span><span class="ri-t">Tax-free for qualified medical, not counted in MAGI. Both spouses use for Medicare Part B/D premiums, Medigap, dental, vision, hearing. Stop contributions when either spouse enrolls in Medicare.</span></div>
+    <div class="ri"><span class="bdg bdg-g">QCDs (70½+)</span><span class="ri-t">Qualified Charitable Distributions from IRA up to $105k/yr per spouse ($210k combined). Counts against RMD but NOT as MAGI. Massive lever if charitably inclined.</span></div>
+    <div class="ri"><span class="bdg bdg-b">Muni bonds</span><span class="ri-t">Federal tax-exempt interest not counted in MAGI. At 22% MFJ bracket: 3.5% muni = 4.49% taxable equivalent. Ideal for buffer Tier 3 and taxable brokerage.</span></div>
+    <div class="ri"><span class="bdg bdg-a">IRMAA appeal</span><span class="ri-t">At 65, file SSA-44 for both spouses citing retirement as "significant income reduction." Moves IRMAA basis to current retirement income. Saves $2,000–4,600/yr per person — $4,000–9,200/yr for both.</span></div>
+  </div>
+
+  <div class="card">
+    <div class="ct">Mortgage strategy — 2.5% fixed through 2051</div>
+    <div class="cs">At 2.5% fixed rate, well below 3.5% inflation, this is negative real-cost debt. The math strongly favors keeping it.</div>
+    <div class="mort-g">
+      <div class="mort-c">
+        <div class="mort-ct">While working (ages 51–55) — keep it</div>
+        <div class="mort-cb">At 35% MFJ bracket: after-tax cost of 2.5% mortgage ≈ <strong>1.63%</strong>. Portfolio earns 7%. Spread: +5.37%/yr on every dollar not used for payoff. SALT cap now $40k (OBBBA, 2025–2029) for MFJ with phasedown above $500k AGI — you'll get partial benefit. Itemize: mortgage interest + property tax (up to SALT cap) + charitable (DAF) should exceed $32.3k standard deduction MFJ.</div>
+      </div>
+      <div class="mort-c">
+        <div class="mort-ct">During retirement (ages 55–69) — still keep it</div>
+        <div class="mort-cb">At 22% or lower bracket in retirement: after-tax cost ≈ <strong>1.95%</strong>. Still below inflation. Mortgage payment provides forced structure to annual spending. The $85k/yr stays in your budget through age 76 (payoff in 2051). Floor spending remains ~$120k until then — factor this into buffer sizing. After SS starts at 70, combined SS (~$219k/yr) covers most of the mortgage payment in years 70–76.</div>
+      </div>
+    </div>
+    <div class="ib ib-g"><strong>Do not pay off.</strong> At 2.5%, every dollar used for payoff earns 2.5% risk-free but forfeits 7% portfolio growth — a 4.5% annual opportunity cost. The mortgage self-extinguishes in 2051 (age 76). Over 25 years of retirement, the ~5% annual spread on the outstanding balance compounds to significant wealth. The key insight: your mortgage rate is below the risk-free rate on T-Bills (~4.5–5%), meaning even your buffer earns more than the mortgage costs. After SS starts at 70, the $85k mortgage payment is largely covered by combined SS income — the portfolio pressure drops sharply for the final 6 years (ages 70–76).</div>
+    
+    <div class="sbg" style="margin-top:12px">
+      <div class="sbg-t">Tax optimization strategies for mortgage during retirement</div>
+      <div style="display:flex;flex-direction:column;gap:9px">
+        <div style="display:flex;gap:9px;align-items:flex-start"><span class="bdg bdg-g" style="margin-top:1px">Itemize MFJ</span><span class="tier-b">Mortgage interest + property tax (up to SALT cap) + charitable giving (DAF, QCDs). If combined exceeds $32.3k standard deduction MFJ, itemize. "Bunching" charitable contributions every 2 years via DAF can alternate between itemizing and standard deduction — maximizing both.</span></div>
+        <div style="display:flex;gap:9px;align-items:flex-start"><span class="bdg bdg-b" style="margin-top:1px">SALT cap</span><span class="tier-b">OBBBA raised SALT to $40k (2025–2029) but phases down for AGI >$500k MFJ. In retirement at lower income, you may get the full $40k: property tax (~$25k?) + state taxes. After 2029, SALT reverts to $10k — plan charitable bunching around this change. If you move to NV: NV has no income tax, so your SALT is property tax only.</span></div>
+        <div style="display:flex;gap:9px;align-items:flex-start"><span class="bdg bdg-a" style="margin-top:1px">Rate arb</span><span class="tier-b">While mortgage costs 2.5%: put equivalent cash in T-Bills or HYSA at 4.5–5%. You earn ~2%/yr net spread on the outstanding balance — effectively getting paid to hold the mortgage. At $500k remaining balance, that's ~$10k/yr in free yield.</span></div>
+        <div style="display:flex;gap:9px;align-items:flex-start"><span class="bdg bdg-a" style="margin-top:1px">Post-2051</span><span class="tier-b">Mortgage ends naturally at age 76. Floor spending drops from $120k to ~$50k. By this point SS has been flowing for 6 years and RMDs have started — floor spending is comfortably covered by income streams alone. The 21-year period (ages 55–76) where floor includes mortgage is the reason the 3-year buffer and discretionary flex lever are critical: in a bad market, you can cut discretionary but not the $85k mortgage payment.</span></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="ct">Tax-loss harvesting (TLH) framework</div>
+    <div class="tlh" style="border-left-color:var(--green)">
+      <div class="tlh-t">Now (ages 51–55) — build loss carryforward</div>
+      <div class="tlh-b">Harvest losses aggressively in taxable brokerage. Use substantially-similar funds: VTI → SCHB, VOO → IVV, VXUS → IXUS. Losses offset ordinary income ($3k/yr cap MFJ) + unlimited capital gains. Build $100–200k carryforward for free gains-realization power in retirement.</div>
+    </div>
+    <div class="tlh" style="border-left-color:var(--blue)">
+      <div class="tlh-t">Early retirement (55–65) — coordinate with replenishment</div>
+      <div class="tlh-b">TLH offsets gains from rebalancing and buffer replenishment sales. In down-market quarters: harvest losses immediately, swap to similar fund, let the buffer absorb spending.</div>
+    </div>
+    <div class="tlh" style="border-left-color:var(--purple)">
+      <div class="tlh-t">Tax-gain harvesting (55–65) — the 0% LTCG opportunity</div>
+      <div class="tlh-b">If combined MAGI drops below $94,050 (MFJ) in any retirement year, LTCG is taxed at 0%. Intentionally sell appreciated positions — step up cost basis — then repurchase. Zero tax, permanently higher basis. Most powerful in early retirement before Roth conversions raise MAGI.</div>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="ct">Long-term care — upgrade for both spouses</div>
+    <div class="ri"><span class="bdg bdg-g">Recommended: Hybrid LTC</span><span class="ri-t">Life insurance + LTC rider (Lincoln MoneyGuard, Nationwide CareMatters, OneAmerica Asset Care). $200–250k single premium per spouse buys $600k–$1M in LTC benefits each. If unused, heirs receive death benefit. Buy both policies at 51.</span></div>
+    <div class="ri"><span class="bdg bdg-a">Self-insure gap</span><span class="ri-t">Alzheimer's care at $10–15k/month for 8–10 years = $960k–$1.8M per spouse. Two spouses doubles the tail risk. Insure years 2+ for both, self-fund year 1.</span></div>
+    <div class="ri"><span class="bdg bdg-b">Tax angle</span><span class="ri-t">Qualified LTC premiums deductible as medical (above 7.5% AGI MFJ). HSA funds pay LTC insurance premiums tax-free after 65. OBBBA's Medicaid changes (2028+) include $1M home equity cap for eligibility — plan accordingly.</span></div>
+  </div>
+</div>
+
+<!-- ESTATE PLAN -->
+<div id="est" class="pane">
+  <div class="card" style="border-color:var(--blue)">
+    <div class="ct" style="color:var(--blue)">OBBBA (signed July 4, 2025) — federal estate tax permanently resolved</div>
+    <div class="cs">The One Big Beautiful Bill Act permanently raised the federal estate/gift/GST exemption. No more sunset anxiety.</div>
+    <div class="g4">
+      <div class="sc"><div class="sc-l">Federal exemption (2026+)</div><div class="sc-v g">$15M</div></div>
+      <div class="sc"><div class="sc-l">MFJ combined (portability)</div><div class="sc-v g">$30M</div></div>
+      <div class="sc"><div class="sc-l">Your est. estate</div><div class="sc-v">$6.5M+</div></div>
+      <div class="sc"><div class="sc-l">Federal estate tax due</div><div class="sc-v g">$0</div></div>
+    </div>
+    <div class="ib ib-g">At $6.5M, you are well below the $30M MFJ federal exemption. Federal estate tax is permanently a non-issue for your estate. However, the exemption is indexed to inflation from 2027 — file portability election on first spouse's death (IRS Form 706) to preserve the deceased spouse's unused exclusion. This is free insurance even when clearly under the limit.</div>
+  </div>
+
+  <div class="card" style="border-color:var(--red)">
+    <div class="ct" style="color:var(--red)">WA state estate tax — SB 6347 (updated rates, effective July 2026)</div>
+    <div class="cs">WA estate tax is separate from federal. New SB 6347 restores pre-2025 rates (top rate: 20%, down from 35%). $3M exclusion retained, NOT indexed for inflation.</div>
+    <div class="g4">
+      <div class="sc"><div class="sc-l">WA exclusion</div><div class="sc-v">$3.0M</div></div>
+      <div class="sc"><div class="sc-l">Your estate</div><div class="sc-v r">$6.5M+</div></div>
+      <div class="sc"><div class="sc-l">WA taxable excess</div><div class="sc-v a">~$3.5M</div></div>
+      <div class="sc"><div class="sc-l">Est. WA estate tax</div><div class="sc-v r">~$460k</div></div>
+    </div>
+    <div class="ib ib-r">WA estate tax rates run 10–20% on the excess above $3M. The $3M exclusion does NOT adjust for inflation and WA does NOT allow portability between spouses — each spouse needs their own $3M exclusion via proper trust planning (A/B trust). Without an A/B trust, only one $3M exclusion is available. With proper planning: $6M combined exclusion reduces exposure significantly.</div>
+  </div>
+
+  <div class="card" style="border-color:var(--red)">
+    <div class="ct" style="color:var(--red)">WA millionaire tax — SB 6346 (effective Jan 1, 2028)</div>
+    <div class="cs">9.9% tax on WA household income exceeding $1M/year. Applies to residents, part-year residents, and nonresidents with WA-source income. First returns due April 2029.</div>
+    <div class="ri"><span class="bdg bdg-r">Critical</span><span class="ri-t"><strong style="color:var(--text)">$1M threshold per household, NOT per person.</strong> Unlike federal MFJ, the $1M is not doubled for married couples. Large Roth conversions, capital gains from buffer replenishment, or RMDs could push you over $1M in any given year. At $250k spend + $150k Roth conversion + $100k cap gains = $500k — safe. But large one-time events (property sale, stock windfall) could trigger it.</span></div>
+    <div class="ri"><span class="bdg bdg-a">Planning</span><span class="ri-t"><strong style="color:var(--text)">Roth conversion pacing matters.</strong> Converting $350k/yr is safe if total household income stays under $1M. But if combined with dividends, capital gains, and other income, you could inadvertently cross the $1M line. Model total AGI before each year's conversion.</span></div>
+    <div class="ri"><span class="bdg bdg-b">Credits</span><span class="ri-t"><strong style="color:var(--text)">Offsetting credits available:</strong> WA capital gains tax credit (avoids double-tax on same income), B&O tax credit, other state income tax credit (OSTC) if you have income taxed in another state. Charitable deduction up to $100k against WA taxable income. Pass-through entity tax (PTET) election available for business owners.</span></div>
+    <div class="ri"><span class="bdg bdg-r">Legal risk</span><span class="ri-t"><strong style="color:var(--text)">Constitutionality uncertain.</strong> Legal challenges are underway — WA Supreme Court has granted accelerated review in Heywood v. Hobbs. The tax may be struck down or modified. However, plan as if it will survive — don't rely on litigation outcomes for financial planning.</span></div>
+    <div class="ib ib-a">The combination of WA's 9.9% millionaire tax, 7% capital gains tax, and 10–20% estate tax makes WA one of the most aggressive state tax environments for high-net-worth retirees. NV residency eliminates all three. See the WA vs NV comparison table below.</div>
+  </div>
+
+  <div class="card">
+    <div class="ct">WA vs NV — state residency strategy matrix (today's $ at retirement)</div>
+    <div class="cs">20-year cumulative tax impact comparison. NV has zero income tax, zero capital gains tax, zero estate tax.</div>
+    <table class="cmp-tbl">
+      <thead>
+        <tr>
+          <th>Wealth tier</th>
+          <th>WA strategy</th>
+          <th>NV strategy</th>
+          <th>20-yr delta (vs NV)</th>
+          <th>Recommendation</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>&lt;$5M</td>
+          <td>A/B trust; protect WA $3M exclusion per spouse</td>
+          <td>Not needed</td>
+          <td style="font-weight:600;color:var(--green)">$0–$300k</td>
+          <td>Keep it simple — focus on WA estate planning, not relocation</td>
+        </tr>
+        <tr>
+          <td>$5M–$10M</td>
+          <td>A/B trust + optimize taxes; annual gifting</td>
+          <td>Selective trust</td>
+          <td style="font-weight:600;color:var(--amber)">$300k–$1.2M</td>
+          <td>Consider NV only if large liquidity event is coming or millionaire tax applies</td>
+        </tr>
+        <tr style="background:var(--blue-bg)">
+          <td style="color:var(--blue-t)">$6.5M ← you</td>
+          <td style="color:var(--blue-t)">A/B trust + Roth conversions + DAF; WA estate tax ~$460k; millionaire tax ~$0–50k/yr if income managed</td>
+          <td style="color:var(--blue-t)">NV trust; eliminate estate + income tax</td>
+          <td style="font-weight:600;color:var(--blue-t)">$500k–$1.5M</td>
+          <td style="color:var(--blue-t)"><strong>Establish NV trust now; evaluate full residency move before 2028 millionaire tax effective date</strong></td>
+        </tr>
+        <tr>
+          <td>$10M–$20M</td>
+          <td>A/B + optimize; income + estate tax drag meaningful</td>
+          <td>Trust + consider move</td>
+          <td style="font-weight:600;color:var(--red)">$1.2M–$4M</td>
+          <td>Start NV trust now; plan relocation before major gains events</td>
+        </tr>
+        <tr>
+          <td>$20M–$40M</td>
+          <td>Income + estate tax drag very high</td>
+          <td>Trust + move</td>
+          <td style="font-weight:600;color:var(--red)">$4M–$10M</td>
+          <td>Execute NV trust immediately and plan a clean residency move</td>
+        </tr>
+        <tr>
+          <td>$40M+</td>
+          <td>Very high compounding leakage across all WA taxes</td>
+          <td>Core NV strategy</td>
+          <td style="font-weight:600;color:var(--red)">$10M–$50M+</td>
+          <td>Make NV your base — full trust + residency strategy is essential</td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="ib ib-b" style="margin-top:14px"><strong>NV residency requirements for WA residents:</strong> (1) Establish genuine physical presence — spend 183+ days/yr in NV; (2) Get NV driver's license, voter registration, vehicle registration; (3) Change bank accounts, doctors, mail; (4) Sever WA domicile indicators — WA will audit aggressively, especially after SB 6346; (5) Consider purchasing or leasing NV property (Reno/Las Vegas/Henderson); (6) Timing: complete the move before Jan 1, 2028 to avoid the first year of WA millionaire tax. Note: WA SB 6346 also taxes nonresidents on WA-source income — if you retain WA rental property, business interests, or employment compensation, those remain taxable.</div>
+  </div>
+
+  <div class="card">
+    <div class="ct">What is estate and beneficiary coordination?</div>
+    <div style="font-size:13px;color:var(--muted);line-height:1.8;margin-bottom:12px">It means aligning three things: (1) how assets are <strong style="color:var(--text)">titled</strong> (community property vs. separate in WA), (2) <strong style="color:var(--text)">beneficiary designations</strong> on accounts (these override your will entirely), and (3) <strong style="color:var(--text)">estate documents</strong> (A/B trust, wills, POAs, healthcare directives for both spouses). A mismatch between any of these can send assets to the wrong person, trigger large taxes, or tie assets up in probate for years.</div>
+    <div style="font-size:13px;color:var(--muted);line-height:1.8"><strong style="color:var(--text)">SECURE Act 2.0 impact:</strong> Non-spouse beneficiaries who inherit a traditional IRA must withdraw everything within 10 years and pay ordinary income tax. A $2M traditional IRA to children = $400–600k+ in taxes. A $2M <em>Roth</em> IRA to children = zero tax, same 10-year window. This single difference justifies the entire Roth conversion strategy.</div>
+  </div>
+
+  <div class="card">
+    <div class="ct">Estate reduction and transfer strategies (updated for OBBBA + WA laws)</div>
+    <div class="ri"><span class="bdg bdg-r">Urgent</span><span class="ri-t"><strong style="color:var(--text)">A/B trust (bypass trust).</strong> WA does NOT allow portability. Each spouse's $3M WA exclusion is lost if not captured in a trust. A/B trust splits estate at first death: "B" trust holds up to $3M for children (bypasses surviving spouse's estate). Combined: $6M excluded. Without it: only $3M. This single document saves ~$300k+ in WA estate tax.</span></div>
+    <div class="ri"><span class="bdg bdg-g">Start now</span><span class="ri-t"><strong style="color:var(--text)">Annual gifting (MFJ).</strong> $19k/person tax-free (2025). Both spouses give: $38k/person. To 2 children: $76k/yr. Over 10 years: $760k removed from estate. 529 superfunding: $95k per spouse per child ($380k total for 2 children), front-loading 5 years of annual exclusion gifts at once. Under OBBBA's $15M exemption, these gifts use zero federal lifetime exclusion unless you're above $15M.</span></div>
+    <div class="ri"><span class="bdg bdg-a">High value</span><span class="ri-t"><strong style="color:var(--text)">Donor-advised fund.</strong> Contribute appreciated stock → immediate federal deduction → reduces WA taxable estate → $100k deduction against WA millionaire tax. Fidelity Charitable, Schwab Charitable. "Bunching" strategy: contribute $200k in one year, take standard deduction the next — maximizes total deductions across years.</span></div>
+    <div class="ri"><span class="bdg bdg-b">Long-term</span><span class="ri-t"><strong style="color:var(--text)">Roth IRA as legacy asset.</strong> Best possible asset for heirs: 10-year tax-free distribution. Under OBBBA's permanent $15M/$30M exemption, your estate passes federal-tax-free regardless — but Roth conversions still save heirs from income tax on inherited traditional IRAs. The heirs' savings is the real win.</span></div>
+    <div class="ri"><span class="bdg bdg-p">NV strategy</span><span class="ri-t"><strong style="color:var(--text)">Nevada Incomplete Non-Grantor (NING) trust.</strong> Transfer assets to a NV trust — assets grow outside WA's taxing jurisdiction. WA's SB 6346 specifically adds back NING trust income, so this must be paired with genuine NV residency to be effective. Consult a multi-state trust attorney. If you establish NV residency, a NV dynasty trust can hold assets indefinitely with zero state estate, income, or capital gains tax.</span></div>
+    <div class="ri"><span class="bdg bdg-b">Consider</span><span class="ri-t"><strong style="color:var(--text)">Irrevocable life insurance trust (ILIT).</strong> Life insurance inside ILIT sits outside both federal and WA taxable estate. Death benefit funds the WA estate tax bill. Under OBBBA, federal ILIT need is reduced — but WA estate tax still applies, making ILIT valuable for WA residents. Get quotes now for both spouses at 51.</span></div>
+  </div>
+
+  <div class="card">
+    <div class="ct">Beneficiary designation audit — both spouses, review every 2 years</div>
+    <div class="cs">Beneficiary designations override your will entirely. Wrong designations can redirect millions to the wrong person.</div>
+    <div class="benef-g">
+      <div class="benef-c"><div class="benef-ct">Traditional 401k</div><div class="benef-cb">Spouse as primary (required by law unless waived). Trust as contingent. Heirs get 10-year taxable distribution — most tax-expensive asset to inherit. Reduce balance via Roth conversions. Both spouses' plans should mirror.</div></div>
+      <div class="benef-c"><div class="benef-ct">Roth 401k + Roth IRA</div><div class="benef-cb">Children as primary. Best asset to inherit — 10-year entirely tax-free distribution. Maximize conversions to maximize what children receive tax-free. Most valuable legacy asset.</div></div>
+      <div class="benef-c"><div class="benef-ct">Taxable brokerage</div><div class="benef-cb">WA community property: both spouses get full step-up at first death (unique to community property states). Do NOT gift appreciated stock while alive — let it pass at death for full step-up.</div></div>
+      <div class="benef-c"><div class="benef-ct">HSA</div><div class="benef-cb">Name spouse as beneficiary — inherits as an HSA, completely tax-free. Non-spouse heirs: entire HSA balance becomes taxable income in year of death. Consider spending HSA during retirement.</div></div>
+    </div>
+  </div>
+</div>
+
+<!-- RMD CALCULATOR -->
+<div id="rmd" class="pane">
+  <div class="card">
+    <div class="ct">Interactive RMD tax calculator — progressive bracket visualization (MFJ)</div>
+    <div class="cs">See how Required Minimum Distributions stack on top of other income and get taxed progressively through the brackets. Drag the slider to compare scenarios.</div>
+
+    <div style="margin-bottom:1.5rem">
+      <div style="display:flex;justify-content:space-between;align-items:baseline;margin-bottom:6px">
+        <span style="font-size:13px;color:var(--muted)">Traditional 401k/IRA balance at age 73</span>
+        <span style="font-size:20px;font-weight:600" id="balOut">$2.0M</span>
+      </div>
+      <input type="range" id="balSlider" min="100" max="4000" step="50" value="2000" style="width:100%;accent-color:var(--navy)">
+      <div style="display:flex;justify-content:space-between;font-size:11px;color:var(--hint);margin-top:3px">
+        <span>$100k (heavy Roth conversion)</span><span>$4.0M (no conversions)</span>
+      </div>
+    </div>
+
+    <div class="g4">
+      <div class="sc"><div class="sc-l">RMD this year</div><div class="sc-v" id="mRmd">—</div></div>
+      <div class="sc"><div class="sc-l">Taxable income (MFJ)</div><div class="sc-v" id="mTaxInc">—</div></div>
+      <div class="sc"><div class="sc-l">Total federal tax</div><div class="sc-v" id="mTax">—</div></div>
+      <div class="sc"><div class="sc-l">Marginal rate</div><div class="sc-v a" id="mMarg">—</div></div>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="ct">How income stacks through progressive brackets (age 73, MFJ 2024)</div>
+    <div style="position:relative;height:80px;border-radius:8px;overflow:hidden;border:1px solid var(--border);margin-bottom:6px">
+      <div class="bzone" style="left:0;width:5.38%;background:#ECFDF5"></div>
+      <div class="bzone" style="left:5.38%;width:11.84%;background:#EAF3DE"></div>
+      <div class="bzone" style="left:17.22%;width:17.81%;background:#EFF6FF"></div>
+      <div class="bzone" style="left:35.03%;width:30.5%;background:#FFFBEB"></div>
+      <div class="bzone" style="left:65.53%;width:34.47%;background:#FEF2F2"></div>
+      <div class="blbl" style="left:0;color:var(--green-t)">10%</div>
+      <div class="blbl" style="left:5.38%;color:#27500A">12%</div>
+      <div class="blbl" style="left:17.22%;color:var(--blue-t)">22%</div>
+      <div class="blbl" style="left:35.03%;color:var(--amber-t)">24%</div>
+      <div class="blbl" style="left:65.53%;color:var(--red-t)">32%+</div>
+      <div class="seg" id="seg-d" style="left:0;background:#B4B2A9;border-radius:0"></div>
+      <div class="seg" id="seg-ss" style="background:#85B7EB"></div>
+      <div class="seg" id="seg-oth" style="background:#D3D1C7"></div>
+      <div class="seg" id="seg-rmd" style="background:#EF9F27"></div>
+      <div id="totalLine" style="position:absolute;top:0;bottom:0;width:2px;background:rgba(0,0,0,0.25);transition:left .3s"></div>
+      <div id="marg-label" style="position:absolute;bottom:52px;font-size:10px;font-weight:500;white-space:nowrap;padding:2px 6px;border-radius:3px;transition:left .3s"></div>
+    </div>
+    <div style="display:flex;justify-content:space-between;font-size:10px;color:var(--hint);padding:0 2px">
+      <span>$0</span><span>$94k</span><span>$201k (22%→24%)</span><span>$384k</span><span>$600k</span>
+    </div>
+    <div class="cl" style="margin-top:8px">
+      <span class="cl-i"><span style="width:10px;height:10px;border-radius:2px;background:#B4B2A9;display:inline-block"></span>Std deduction ($32.3k MFJ)</span>
+      <span class="cl-i"><span style="width:10px;height:10px;border-radius:2px;background:#85B7EB;display:inline-block"></span>Combined SS (85% taxable, ~$106k)</span>
+      <span class="cl-i"><span style="width:10px;height:10px;border-radius:2px;background:#D3D1C7;display:inline-block"></span>Other income ($15k)</span>
+      <span class="cl-i"><span style="width:10px;height:10px;border-radius:2px;background:#EF9F27;display:inline-block"></span>RMD (drag slider)</span>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="ct">Tax breakdown — where each dollar gets taxed</div>
+    <div id="bracketDetail"></div>
+  </div>
+
+  <div class="card">
+    <div class="ct">Side-by-side: with vs. without Roth conversions</div>
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-bottom:10px">
+      <div style="background:var(--red-bg);border-radius:8px;padding:12px">
+        <div style="font-size:12px;font-weight:600;color:var(--red-t);margin-bottom:8px">Without Roth conversions</div>
+        <div id="cmpBad" style="font-size:12px;color:var(--red-t);line-height:1.9"></div>
+      </div>
+      <div style="background:var(--green-bg);border-radius:8px;padding:12px">
+        <div style="font-size:12px;font-weight:600;color:var(--green-t);margin-bottom:8px">With Roth conversions ($500k left)</div>
+        <div id="cmpGood" style="font-size:12px;color:var(--green-t);line-height:1.9"></div>
+      </div>
+    </div>
+    <div style="background:var(--surface2);border-radius:8px;padding:10px;font-size:12px;color:var(--muted)">
+      <strong style="color:var(--text)">Annual tax savings from Roth strategy:</strong> <span id="annualSavings" style="font-weight:600;color:var(--green)">—</span> &nbsp;·&nbsp; Over 15 years (ages 73–88): <span id="lifetimeSavings" style="font-weight:600;color:var(--green)">—</span>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="ct">Cascade effects — hidden RMD costs beyond income tax</div>
+    <div id="cascadeSection"></div>
+  </div>
+</div>
+
+<!-- TIMELINE -->
+<div id="tl" class="pane">
+  <div class="card">
+    <div class="ct">Age-by-age action roadmap (married couple)</div>
+    <div class="cs" style="margin-bottom:20px">Key milestones, decisions, and actions across your retirement journey</div>
+
+    <div class="tl-item">
+      <div class="tl-col"><div class="tl-dot" style="background:#DBEAFE;color:#1E40AF">51</div><div class="tl-line"></div></div>
+      <div style="flex:1;padding-top:4px;padding-bottom:24px">
+        <div class="tl-t">Now — foundation sprint (most critical year)</div>
+        <div class="tl-b">Max 401k + catch-up ($30.5k) &middot; Max HSA family ($9,300) &middot; Draft estate plan for both spouses: A/B trust, wills, POA, healthcare directives &middot; Audit beneficiary designations on every account (both spouses) &middot; Open DAF and contribute appreciated stock &middot; Get hybrid LTC quotes for both spouses &middot; Begin Roth conversions (fill 22% MFJ bracket) &middot; Build taxable savings to $100k+/yr &middot; Begin systematic TLH &middot; Evaluate NV residency timeline before 2028 millionaire tax</div>
+      </div>
+    </div>
+
+    <div class="tl-item">
+      <div class="tl-col"><div class="tl-dot" style="background:#DBEAFE;color:#1E40AF">53</div><div class="tl-line"></div></div>
+      <div style="flex:1;padding-top:4px;padding-bottom:24px">
+        <div class="tl-t">Ages 53–54 — retirement runway + NV residency decision</div>
+        <div class="tl-b">Decision point: stay in WA or establish NV residency before Jan 1, 2028 &middot; If NV: begin physical presence, DL, voter reg, property &middot; Begin building Tier 3 buffer in advance of retirement &middot; Gradually reduce equity allocation from 90% toward 80% &middot; IRMAA preview: model both spouses' age-63 income impact on age-65 Medicare &middot; Keep 2.5% mortgage — natural payoff in 2051 &middot; OBBBA SALT cap ($40k) still available through 2029 — maximize itemization</div>
+      </div>
+    </div>
+
+    <div class="tl-item">
+      <div class="tl-col"><div class="tl-dot" style="background:#D1FAE5;color:#065F46">55</div><div class="tl-line"></div></div>
+      <div style="flex:1;padding-top:4px;padding-bottom:24px">
+        <div class="tl-t">Age 55 — retirement begins</div>
+        <div class="tl-b">Rule of 55: access current employer 401k penalty-free (do not roll over until 59½) &middot; Fund 3-year buffer ($861k) immediately &middot; Begin aggressive Roth conversions (fill 22% MFJ bracket ~$200k/yr) &middot; Keep 2.5% mortgage — earns positive carry &middot; Activate quarterly replenishment decision rules &middot; Transition portfolio to retirement allocation (70% equity, 17% buffer, 13% bonds) &middot; If in NV: ensure spending 183+ days/yr in NV for domicile protection</div>
+      </div>
+    </div>
+
+    <div class="tl-item">
+      <div class="tl-col"><div class="tl-dot" style="background:#D1FAE5;color:#065F46">59½</div><div class="tl-line"></div></div>
+      <div style="flex:1;padding-top:4px;padding-bottom:24px">
+        <div class="tl-t">Age 59½ — full account access unlocked</div>
+        <div class="tl-b">Roth IRA earnings accessible penalty-free (both spouses) &middot; All 401k/IRA withdrawals penalty-free &middot; 5-year Roth conversion ladder matured &middot; Full flexibility in withdrawal sequencing &middot; Roth balance from 4.5 years of MFJ conversions: $900k–$1.4M+ &middot; Review portfolio vs. plan checkpoint</div>
+      </div>
+    </div>
+
+    <div class="tl-item">
+      <div class="tl-col"><div class="tl-dot" style="background:#FEF3C7;color:#92400E">63</div><div class="tl-line"></div></div>
+      <div style="flex:1;padding-top:4px;padding-bottom:24px">
+        <div class="tl-t">Age 63 — IRMAA critical control year (both spouses)</div>
+        <div class="tl-b">Age 63 income = age 65 Medicare premium (2-year lookback) for both spouses &middot; Target combined MAGI below $206k MFJ &middot; Pause Roth conversions if necessary &middot; Use DAF contributions to reduce unavoidable MAGI &middot; File SSA-44 for both spouses at 65</div>
+      </div>
+    </div>
+
+    <div class="tl-item">
+      <div class="tl-col"><div class="tl-dot" style="background:#FEF3C7;color:#92400E">65</div><div class="tl-line"></div></div>
+      <div style="flex:1;padding-top:4px;padding-bottom:24px">
+        <div class="tl-t">Age 65 — Medicare enrollment for both spouses</div>
+        <div class="tl-b">Enroll both spouses in Medicare Parts A, B, D + Medigap (Plan G or N) &middot; File SSA-44 for both citing retirement &middot; Stop HSA contributions immediately &middot; Begin spending HSA tax-free on premiums, dental, vision &middot; Do NOT claim SS — continue to 70 &middot; Resume Roth conversions if IRMAA managed</div>
+      </div>
+    </div>
+
+    <div class="tl-item">
+      <div class="tl-col"><div class="tl-dot" style="background:#D1FAE5;color:#065F46">76</div><div class="tl-line"></div></div>
+      <div style="flex:1;padding-top:4px;padding-bottom:24px">
+        <div class="tl-t">Age 76 — mortgage self-extinguishes (2051)</div>
+        <div class="tl-b">2.5% mortgage pays off naturally after 30 years. Floor spending drops from ~$120k to ~$50k. By now, SS has been flowing for 6 years and RMDs for 3 years — income streams more than cover the reduced floor. Over the 25-year mortgage hold (ages 51–76), you earned ~5%/yr spread on every dollar not used for payoff. The total value of keeping cheap debt: an estimated $400–600k in additional portfolio growth vs. early payoff at retirement.</div>
+      </div>
+    </div>
+
+    <div class="tl-item">
+      <div class="tl-col"><div class="tl-dot" style="background:#D1FAE5;color:#065F46">70</div><div class="tl-line"></div></div>
+      <div style="flex:1;padding-top:4px;padding-bottom:24px">
+        <div class="tl-t">Age 70 — SS begins for both spouses</div>
+        <div class="tl-b">Both spouses claim Social Security &middot; Combined: ~$10,400+/mo nominal by 70 (~$219k/yr after COLA) &middot; 85% of combined SS is taxable: coordinate with Roth draws &middot; Combined SS covers ~45% of spending — dramatic reduction in portfolio draws &middot; Begin QCDs if charitably inclined ($105k/yr per spouse) &middot; Review and update estate plan</div>
+      </div>
+    </div>
+
+    <div class="tl-item">
+      <div class="tl-col"><div class="tl-dot" style="background:#FEE2E2;color:#991B1B">73</div><div class="tl-line" style="background:transparent"></div></div>
+      <div style="flex:1;padding-top:4px">
+        <div class="tl-t">Age 73 — RMDs begin (SECURE Act 2.0)</div>
+        <div class="tl-b">If Roth conversion plan executed: traditional balance ≤$500k → RMDs ~$18–25k/yr (manageable within 12% bracket MFJ) &middot; Without conversion: traditional $2M+ → RMDs $80k+/yr push into 22–24% bracket + may trigger WA millionaire tax if still WA resident &middot; Both spouses' RMDs coordinate with combined SS for bracket optimization &middot; Use QCDs from both spouses' IRAs to redirect excess RMDs &middot; Review estate plan — shift focus to legacy and distribution</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+</div><!-- /main -->
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.js"></script>
+<script>
+// ===== Tab switching =====
+function showTab(id, btn) {
+  var panes = document.querySelectorAll('.pane');
+  var btns = document.querySelectorAll('.nb');
+  for (var i = 0; i < panes.length; i++) panes[i].classList.remove('on');
+  for (var i = 0; i < btns.length; i++) btns[i].classList.remove('on');
+  document.getElementById(id).classList.add('on');
+  btn.classList.add('on');
+  if (id === 'proj' && !projBuilt) { buildProjChart('base'); projBuilt = true; }
+  if (id === 'roth' && !ssBuilt) { buildSSChart(); ssBuilt = true; }
+  if (id === 'rmd' && !rmdBuilt) { updateRMD(); rmdBuilt = true; }
+}
+
+// ===== Portfolio projection (married — both spouses SS) =====
+function calcPortfolio(gr, ir) {
+  var port = 6520000, spend = 287000, labels = [], vals = [];
+  for (var yr = 0; yr <= 35; yr++) {
+    var age = 55 + yr;
+    labels.push(age);
+    vals.push(parseFloat((port / 1e6).toFixed(2)));
+    var ss = 0;
+    if (age >= 70) {
+      var ssAt70 = 124872 * Math.pow(1 + ir, 19);
+      ss = ssAt70 * Math.pow(1.025, age - 70);
+    }
+    port = Math.max(0, port * (1 + gr) - Math.max(0, spend - ss));
+    spend *= (1 + ir);
+  }
+  return { labels: labels, vals: vals };
+}
+
+var bullD  = calcPortfolio(0.09, 0.035);
+var baseD  = calcPortfolio(0.07, 0.035);
+var stressD = calcPortfolio(0.05, 0.04);
+
+document.getElementById('v70').textContent  = '$' + baseD.vals[15].toFixed(1) + 'M';
+document.getElementById('v85').textContent  = '$' + baseD.vals[30].toFixed(1) + 'M';
+document.getElementById('v85s').textContent = '$' + stressD.vals[30].toFixed(1) + 'M';
+
+var projChart = null, projBuilt = false, ssBuilt = false, rmdBuilt = false;
+
+function buildProjChart(scen) {
+  if (projChart) { projChart.destroy(); projChart = null; }
+  var ctx = document.getElementById('projChart').getContext('2d');
+  var datasets = [];
+  if (scen === 'all' || scen === 'bull') {
+    datasets.push({ label: 'Bull 9%', data: bullD.vals, borderColor: '#059669', backgroundColor: 'transparent', borderWidth: 2.5, pointRadius: 0, tension: 0.3 });
+  }
+  if (scen === 'all' || scen === 'base') {
+    datasets.push({ label: 'Base 7%', data: baseD.vals, borderColor: '#2563EB', backgroundColor: 'transparent', borderWidth: 2.5, pointRadius: 0, tension: 0.3 });
+  }
+  if (scen === 'all' || scen === 'stress') {
+    datasets.push({ label: 'Stress 5%', data: stressD.vals, borderColor: '#D97706', backgroundColor: 'transparent', borderWidth: 2, borderDash: [6, 3], pointRadius: 0, tension: 0.3 });
+  }
+  projChart = new Chart(ctx, {
+    type: 'line',
+    data: { labels: baseD.labels, datasets: datasets },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { display: false } },
+      scales: {
+        x: { grid: { color: 'rgba(0,0,0,0.04)' }, ticks: { color: '#94A3B8', font: { size: 11 }, autoSkip: false, maxRotation: 0, callback: function(v, i) { return (55+i) % 5 === 0 ? 'Age '+(55+i) : ''; } } },
+        y: { grid: { color: 'rgba(0,0,0,0.04)' }, ticks: { color: '#94A3B8', font: { size: 11 }, callback: function(v) { return '$'+v.toFixed(0)+'M'; } } }
+      }
+    }
+  });
+}
+
+function switchScen(scen, btn) {
+  var sibs = btn.parentElement.querySelectorAll('.sc-btn');
+  for (var i = 0; i < sibs.length; i++) sibs[i].classList.remove('on');
+  btn.classList.add('on');
+  buildProjChart(scen);
+}
+
+// ===== SS chart =====
+function buildSSChart() {
+  var ctx = document.getElementById('ssChart').getContext('2d');
+  var ages = [];
+  for (var a = 65; a <= 90; a++) ages.push(a);
+  new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: ages,
+      datasets: [
+        { label: 'Claim 65', data: ages.map(function(a) { return Math.round((a-65)*42.564); }), borderColor: '#DC2626', backgroundColor: 'transparent', borderWidth: 2, pointRadius: 0, tension: 0.2 },
+        { label: 'Claim 68', data: ages.map(function(a) { return a >= 68 ? Math.round((a-68)*54.024) : 0; }), borderColor: '#D97706', backgroundColor: 'transparent', borderWidth: 2, pointRadius: 0, tension: 0.2 },
+        { label: 'Claim 70', data: ages.map(function(a) { return a >= 70 ? Math.round((a-70)*62.436) : 0; }), borderColor: '#059669', backgroundColor: 'transparent', borderWidth: 2.5, pointRadius: 0, tension: 0.2 }
+      ]
+    },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { display: false } },
+      scales: {
+        x: { grid: { color: 'rgba(0,0,0,0.04)' }, ticks: { color: '#94A3B8', font: { size: 11 }, autoSkip: false, maxRotation: 0, callback: function(v,i) { return (65+i)%5===0?'Age '+(65+i):''; } } },
+        y: { grid: { color: 'rgba(0,0,0,0.04)' }, title: { display: true, text: 'Cumulative benefit ($k)', color: '#94A3B8', font: { size: 11 } }, ticks: { color: '#94A3B8', font: { size: 11 }, callback: function(v) { return v>=1000?'$'+(v/1000).toFixed(1)+'M':'$'+v+'k'; } } }
+      }
+    }
+  });
+}
+
+// ===== RMD Calculator =====
+var maxScale = 600000;
+var deduction = 32300;
+var ssGross = 124872;
+var ssTaxable = Math.round(ssGross * 0.85);
+var otherInc = 15000;
+var lifeExp = 26.5;
+var brackets = [
+  {limit:23200,rate:0.10},{limit:94300,rate:0.12},{limit:201050,rate:0.22},
+  {limit:383900,rate:0.24},{limit:487450,rate:0.32},{limit:731200,rate:0.35},
+  {limit:Infinity,rate:0.37}
+];
+
+function calcTax(balance) {
+  var rmd = balance / lifeExp;
+  var gross = rmd + ssTaxable + otherInc;
+  var taxable = Math.max(0, gross - deduction);
+  var tax = 0, margRate = 0.10, prev = 0, detail = [];
+  for (var i = 0; i < brackets.length; i++) {
+    if (taxable <= prev) break;
+    var inB = Math.min(taxable, brackets[i].limit) - prev;
+    if (inB > 0) { tax += inB * brackets[i].rate; margRate = brackets[i].rate; detail.push({rate:brackets[i].rate, amount:inB, tax:inB*brackets[i].rate}); }
+    prev = brackets[i].limit;
+  }
+  return {rmd:rmd, gross:gross, taxable:taxable, tax:tax, margRate:margRate, detail:detail};
+}
+
+function fmt(n) { return '$'+Math.round(n).toLocaleString(); }
+function pct(n) { return Math.round(n*100)+'%'; }
+
+function updateRMD() {
+  var bal = parseInt(document.getElementById('balSlider').value) * 1000;
+  document.getElementById('balOut').textContent = bal >= 1000000 ? '$'+(bal/1e6).toFixed(1)+'M' : '$'+Math.round(bal/1000)+'k';
+  var r = calcTax(bal);
+  document.getElementById('mRmd').textContent = fmt(r.rmd);
+  document.getElementById('mTaxInc').textContent = fmt(r.taxable);
+  document.getElementById('mTax').textContent = fmt(r.tax);
+  var me = document.getElementById('mMarg');
+  me.textContent = pct(r.margRate);
+  me.style.color = r.margRate <= 0.12 ? 'var(--green)' : r.margRate <= 0.22 ? 'var(--amber)' : 'var(--red)';
+
+  var dp = deduction/maxScale*100, sp = ssTaxable/maxScale*100, op = otherInc/maxScale*100;
+  var rp = Math.min(r.rmd/maxScale*100, 100-dp-sp-op);
+  var tp = Math.min(r.gross/maxScale*100, 100);
+  document.getElementById('seg-d').style.width=dp.toFixed(2)+'%'; document.getElementById('seg-d').style.left='0%';
+  document.getElementById('seg-ss').style.left=dp.toFixed(2)+'%'; document.getElementById('seg-ss').style.width=sp.toFixed(2)+'%';
+  document.getElementById('seg-oth').style.left=(dp+sp).toFixed(2)+'%'; document.getElementById('seg-oth').style.width=op.toFixed(2)+'%';
+  document.getElementById('seg-rmd').style.left=(dp+sp+op).toFixed(2)+'%'; document.getElementById('seg-rmd').style.width=Math.max(0,rp).toFixed(2)+'%';
+  document.getElementById('totalLine').style.left=tp.toFixed(2)+'%';
+  var ml = document.getElementById('marg-label');
+  ml.style.left=Math.min(tp,88).toFixed(2)+'%';
+  ml.textContent='Marginal: '+pct(r.margRate);
+  ml.style.background=r.margRate<=0.12?'#ECFDF5':r.margRate<=0.22?'#FFFBEB':'#FEF2F2';
+  ml.style.color=r.margRate<=0.12?'#065F46':r.margRate<=0.22?'#92400E':'#991B1B';
+
+  var det='';
+  r.detail.forEach(function(d){det+='<div class="rmd-krow"><span>'+pct(d.rate)+' on '+fmt(d.amount)+'</span><span style="font-weight:600">'+fmt(d.tax)+'</span></div>';});
+  det+='<div class="rmd-krow" style="border-top:1px solid var(--border2)"><span style="font-weight:600">Total federal tax</span><span style="font-weight:600">'+fmt(r.tax)+' ('+(r.taxable>0?(r.tax/r.taxable*100).toFixed(1):'0')+'% effective)</span></div>';
+  document.getElementById('bracketDetail').innerHTML=det;
+
+  var good = calcTax(500000);
+  document.getElementById('cmpBad').innerHTML='RMD: '+fmt(r.rmd)+'<br>Taxable income: '+fmt(r.taxable)+'<br>Marginal rate: <strong>'+pct(r.margRate)+'</strong><br>Total tax: <strong>'+fmt(r.tax)+'</strong>';
+  document.getElementById('cmpGood').innerHTML='RMD: '+fmt(good.rmd)+'<br>Taxable income: '+fmt(good.taxable)+'<br>Marginal rate: <strong>'+pct(good.margRate)+'</strong><br>Total tax: <strong>'+fmt(good.tax)+'</strong>';
+  var as = Math.max(0, r.tax - good.tax);
+  document.getElementById('annualSavings').textContent = fmt(as)+'/yr';
+  document.getElementById('lifetimeSavings').textContent = fmt(as*15)+'+';
+
+  var cs='';
+  var irmaaHit = r.taxable > 206000;
+  cs+='<div class="rmd-krow"><span>IRMAA Medicare surcharge (both spouses)</span><span style="font-weight:600;color:'+(irmaaHit?'var(--red)':'var(--green)')+'">'+(irmaaHit?'Triggered — +$384–420/mo × 2 spouses':'Safe — base premium for both')+'</span></div>';
+  cs+='<div class="rmd-krow"><span>Combined SS income % taxable</span><span style="font-weight:600">85% (income well above $44k MFJ threshold)</span></div>';
+  var waMillTax = (r.rmd + ssTaxable + otherInc) > 1000000;
+  cs+='<div class="rmd-krow"><span>WA millionaire tax (9.9%, if WA resident)</span><span style="font-weight:600;color:'+(waMillTax?'var(--red)':'var(--green)')+'">'+(waMillTax?'Triggered — 9.9% on income above $1M':'Not triggered at this income level')+'</span></div>';
+  cs+='<div class="rmd-krow"><span>LTCG rate on dividends</span><span style="font-weight:600">'+(r.taxable>94050?'15%':'0%')+' (income '+(r.taxable>94050?'above':'below')+' 0% threshold MFJ)</span></div>';
+  document.getElementById('cascadeSection').innerHTML=cs;
+
+  if(irmaaHit){document.getElementById('cascadeSection').innerHTML+='<div class="ib ib-a">IRMAA adds $384–420/mo per spouse in surcharges — up to $10,080/yr for a married couple. This never appears on your tax return but is a direct income-driven cost. Keeping combined MAGI under $206k MFJ eliminates it entirely.</div>';}
+  else{document.getElementById('cascadeSection').innerHTML+='<div class="ib ib-g">At this income, IRMAA surcharges are not triggered for either spouse. This is the result of keeping traditional IRA balances low through Roth conversions.</div>';}
+  if(waMillTax){document.getElementById('cascadeSection').innerHTML+='<div class="ib ib-r" style="margin-top:6px">WA millionaire tax applies 9.9% on household income above $1M. At this RMD level combined with SS and other income, you would owe approximately '+fmt((r.rmd+ssTaxable+otherInc-1000000)*0.099)+'/yr in WA state tax alone. NV residency eliminates this entirely.</div>';}
+}
+
+document.getElementById('balSlider').addEventListener('input', updateRMD);
+</script>
+</body>
+</html>

--- a/retirement_master_plan_2.html
+++ b/retirement_master_plan_2.html
@@ -116,6 +116,11 @@ body{font-family:-apple-system,'Helvetica Neue',Arial,sans-serif;background:var(
   .cmp-tbl{font-size:11px}
 }
 </style>
+
+<!-- Wealth Suite shared shell -->
+<link rel="stylesheet" href="assets/suite.css?v=2">
+<script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
+<script src="assets/suite.js?v=2" defer></script>
 </head>
 <body>
 


### PR DESCRIPTION
## Summary

Consolidate the five standalone HTML tools into a navigable Material Design 3 suite without introducing a build step. Stays GitHub Pages compatible.

- New `index.html` MD3 dashboard with responsive module grid linking to all 5 tools
- New `assets/suite.css` + `assets/suite.js` — MD3 design tokens, system-preference-aware light/dark, theme toggle, persistent topbar injected into every tool
- Track 3 previously-untracked tools (`retirement_master_plan_2.html`, `portfolio_review.html`, `golden_ratio_portfolio_dashboard.html`); the golden-ratio file was a bare HTML fragment and is now wrapped in proper `<!doctype>/<html>/<head>/<body>` scaffolding with fallback values for the 16 `--color-*` design tokens it referenced (light + dark variants)
- Cross-tool navigation: clicking **Dashboard** from any page returns to the landing; clicking any module label jumps to that tool

## Implementation notes

- Topbar uses `position: fixed` (not `sticky`) so it survives arbitrary body layouts. `TaxAssetCalcv4.html` uses Tailwind `flex items-center justify-center` on `<body>`, which would have vertically centered a sticky bar mid-page.
- Body gets a 64px top-padding via `.suite-body` (dashboard) or `.suite-tool-shell` (added by `suite.js` on tool pages) to keep content out from under the fixed bar.
- Suite asset URLs are version-stamped (`?v=2`) so future shell edits cache-bust cleanly in browsers serving these files from GitHub Pages caches.
- Tool internals are untouched — each tool only got a 3-line `<head>` insertion (suite.css link, inline theme bootstrap to prevent FOUC, deferred suite.js).

## Test plan

- [x] Dashboard renders 6 module cards, hero, theme toggle — no console errors
- [x] Every tool page shows the suite topbar with working Dashboard + cross-module links
- [x] Active-page state highlights correctly (Tax / Assets / Retirement / Portfolio / Golden φ)
- [x] Theme toggle (system → light → dark) persists across pages via localStorage
- [x] Assets page (Tailwind-`flex` body) now shows topbar at top, not mid-page
- [x] Golden ratio fragment renders standalone after HTML wrapping
- [ ] (manual) Verify on GitHub Pages once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
