### PR TITLE
Deploy Pages via GitHub Actions (unblocks private repos)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,69 @@
+# Deploy the Wealth Suite to GitHub Pages via GitHub Actions.
+#
+# Replaces the legacy Pages builder. Works on both public and private
+# repos (legacy Pages requires public on free tier; the Actions-based
+# deploy does not). After this workflow is on `main`, flip the Pages
+# source in repo settings to "GitHub Actions":
+#   gh api -X PUT repos/<owner>/<repo>/pages -f build_type=workflow
+#
+# Trigger on push to main or manually via the Actions UI / `gh workflow run pages.yml`.
+
+name: Deploy site to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    # Skip runs that only touch developer-only paths
+    paths-ignore:
+      - '.claude/**'
+      - '**/*.md'
+      - '.gitignore'
+  workflow_dispatch:
+
+# Required by actions/deploy-pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only one Pages deploy at a time; let in-flight finish (don't cancel)
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Stage site (exclude dev-only paths)
+        run: |
+          mkdir -p _site
+          rsync -a \
+            --exclude='.git' \
+            --exclude='.github' \
+            --exclude='.claude' \
+            --exclude='_site' \
+            --exclude='.DS_Store' \
+            --exclude='node_modules' \
+            --exclude='*.swp' \
+            ./ _site/
+          echo "Staged file count: $(find _site -type f | wc -l)"
+          ls -la _site/
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Replace the legacy GitHub Pages builder with an Actions workflow that uses `actions/deploy-pages`. This allows the site at https://kkgeek.github.io/tools/ to keep deploying even if the repo is flipped to private (legacy Pages requires public on the free tier; Actions-based deploy does not).

## Why now

Toggling the repo private earlier in this session broke Pages, and flipping back to public left it in a `status: null` state that needed a manual rebuild. Going forward, this workflow makes deploys idempotent and visibility-agnostic.

## What the workflow does

- Triggers on push to `main` (and manual `workflow_dispatch`)
- Skips runs whose only changes are in `.claude/**`, `*.md`, or `.gitignore`
- Stages the site into `_site/` via `rsync`, excluding `.git`, `.github`, `.claude`, `node_modules`, `.DS_Store` — keeps the deployed artifact lean
- Pipeline: `actions/checkout@v4` → `actions/configure-pages@v5` → `actions/upload-pages-artifact@v3` → `actions/deploy-pages@v4`
- Concurrency-gated to one deploy at a time, doesn't cancel in-flight

## Activation steps (after this merges)

The workflow file alone doesn't switch Pages' source — that's a repo setting. Once merged:

```sh
# Tell Pages to use the workflow instead of the legacy builder
gh api -X PUT repos/kkgeek/tools/pages -f build_type=workflow

# Kick off the first workflow-driven deploy
gh workflow run pages.yml --ref main
```

I'll run these for you immediately after you merge.

## Test plan

- [x] YAML lints clean
- [x] rsync excludes verified against repo layout (\`.claude/launch.json\` won't ship; site assets do)
- [ ] (post-merge) `gh api -X PUT … -f build_type=workflow` returns 204
- [ ] (post-merge) First workflow run reaches \"deploy\" job successfully
- [ ] (post-merge) https://kkgeek.github.io/tools/ returns HTTP 200 and serves \`index.html\`
- [ ] (post-merge) Flip repo to private briefly to confirm Pages keeps working

🤖 Generated with [Claude Code](https://claude.com/claude-code)