### PR TITLE
Add shared theme layer (design-handoff palette) across all pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,23 @@ Phase 12 additions (chat polish):
 - `assets/suite.css?v=15` (index.html only — `.suite-chat__open` link
   chip + focus-visible outlines on chat buttons/links/inputs)
 
+Phase 13 additions (design-handoff retheme — step 1 of
+`design/Wealth-Suite/design_handoff_wealth_suite/README.md`):
+- `assets/theme.css?v=1` (ALL pages — linked immediately AFTER
+  `suite.css` so it wins the `:root` cascade). New shared theme layer:
+  ships the handoff design tokens (`--bg`/`--surface`/`--primary` green
+  `#2E7D32`/`--text`… + light & dark) and REMAPS the legacy
+  `--md-sys-color-*` / `--status-*` names onto them via `var()`, so the
+  injected shell topbar + every vanilla tool (which already consume
+  those vars) repaint to the new look with no per-tool edits. Also
+  `@import`s Roboto / Roboto Mono and sets the base UI font.
+  Load-order is load-bearing: legacy remaps share `:root` specificity
+  with suite.css and rely on being declared later. The 5 Tailwind tools
+  (portfolio_tracker, expenses, TaxEstimatorV5, roth_conversion,
+  TaxAssetCalcv4) pick up the topbar + page chrome only; their internal
+  utility-class colours still need the deferred pixel-perfect reskin
+  (handoff steps 2–4).
+
 ## Constraints to preserve
 
 - **Zero build step.** No Vite/Webpack until scope demands it.

--- a/TaxAssetCalcv4.html
+++ b/TaxAssetCalcv4.html
@@ -33,6 +33,7 @@
 
     <!-- Wealth Suite shared shell -->
     <link rel="stylesheet" href="assets/suite.css?v=6">
+    <link rel="stylesheet" href="assets/theme.css?v=1">
     <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
     <script src="assets/suite-state.js?v=7" defer></script>
     <script src="assets/suite.js?v=11" defer></script>

--- a/TaxEstimatorV5.html
+++ b/TaxEstimatorV5.html
@@ -18,6 +18,7 @@
 
   <!-- Wealth Suite shared shell -->
   <link rel="stylesheet" href="assets/suite.css?v=6">
+  <link rel="stylesheet" href="assets/theme.css?v=1">
   <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
   <script src="assets/suite-state.js?v=7" defer></script>
   <script src="assets/suite.js?v=11" defer></script>

--- a/assets/theme.css
+++ b/assets/theme.css
@@ -1,0 +1,113 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Roboto+Mono:wght@400;500&display=swap');
+
+/* =============================================================
+ * Wealth Suite — shared theme layer (design-handoff palette)
+ * -------------------------------------------------------------
+ * Single source of truth for colour + typography across the whole
+ * suite. Ships the design-handoff tokens (--bg / --surface /
+ * --primary green #2E7D32 / Roboto) and REMAPS the legacy
+ * --md-sys-color-* / --status-* names onto them so every page that
+ * already consumes those vars (the injected shell topbar + the
+ * vanilla tools) repaints to the new look with no per-tool edits.
+ *
+ * LOAD ORDER MATTERS: link this AFTER assets/suite.css on every
+ * page. The legacy remaps below share :root's specificity (0,1,0)
+ * with suite.css, so the later-loaded file wins. The remaps point
+ * at the handoff tokens via var(), so they follow light/dark
+ * automatically — only the handoff tokens are redefined for dark.
+ * ============================================================= */
+
+:root {
+  /* ---- design-handoff tokens · LIGHT (default) ---- */
+  --bg:#F1F3F4; --surface:#FFFFFF; --surface-2:#F1F3F4; --track:#E3E6E8;
+  --border:#E1E4E8; --text:#202124; --text-2:#5F6368; --text-3:#80868B;
+  --primary:#2E7D32; --primary-strong:#1B5E20; --primary-weak:#E6F4EA;
+  --on-primary:#FFFFFF; --primary-text:#1E6B2A;
+  --pos:#188038; --pos-weak:rgba(24,128,56,.10);
+  --neg:#D93025; --neg-weak:rgba(217,48,37,.10);
+  --warn:#E37400; --warn-weak:rgba(227,116,0,.10);
+  --cat2:#4285F4; --cat2-weak:rgba(66,133,244,.10);
+  --cat3:#00897B; --cat4:#F9AB00; --cat5:#9AA0A6;
+  --shadow:0 1px 2px rgba(60,64,67,.10),0 1px 3px rgba(60,64,67,.06);
+  --shadow-2:0 1px 3px rgba(60,64,67,.12),0 4px 8px rgba(60,64,67,.08);
+
+  /* ---- legacy MD3 names → handoff palette ---- */
+  --md-sys-color-primary:                   var(--primary);
+  --md-sys-color-on-primary:                var(--on-primary);
+  --md-sys-color-primary-container:         var(--primary-weak);
+  --md-sys-color-on-primary-container:      var(--primary-text);
+
+  --md-sys-color-secondary:                 var(--text-2);
+  --md-sys-color-on-secondary:              var(--on-primary);
+  --md-sys-color-secondary-container:       var(--surface-2);
+  --md-sys-color-on-secondary-container:    var(--text);
+
+  --md-sys-color-tertiary:                  var(--cat2);
+  --md-sys-color-on-tertiary:               #FFFFFF;
+  --md-sys-color-tertiary-container:        var(--cat2-weak);
+  --md-sys-color-on-tertiary-container:     var(--cat2);
+
+  --md-sys-color-error:                     var(--neg);
+  --md-sys-color-on-error:                  #FFFFFF;
+  --md-sys-color-error-container:           var(--neg-weak);
+
+  --md-sys-color-background:                var(--bg);
+  --md-sys-color-on-background:             var(--text);
+  --md-sys-color-surface:                   var(--bg);
+  --md-sys-color-on-surface:                var(--text);
+  --md-sys-color-on-surface-variant:        var(--text-2);
+  --md-sys-color-surface-container-lowest:  var(--surface);
+  --md-sys-color-surface-container-low:     var(--surface);
+  --md-sys-color-surface-container:         var(--surface-2);
+  --md-sys-color-surface-container-high:    var(--surface-2);
+  --md-sys-color-surface-container-highest: var(--track);
+
+  --md-sys-color-outline:                   var(--text-3);
+  --md-sys-color-outline-variant:           var(--border);
+  --md-sys-color-inverse-surface:           var(--text);
+  --md-sys-color-inverse-on-surface:        var(--bg);
+
+  --md-sys-color-success:                   var(--pos);
+  --md-sys-color-success-container:         var(--pos-weak);
+  --md-sys-color-on-success-container:      var(--pos);
+
+  /* ---- semantic status names → handoff palette ---- */
+  --status-positive:           var(--pos);
+  --status-positive-container: var(--pos-weak);
+  --status-positive-on:        var(--pos);
+  --status-warning:            var(--warn);
+  --status-warning-container:  var(--warn-weak);
+  --status-warning-on:         var(--warn);
+  --status-critical:           var(--neg);
+  --status-critical-container: var(--neg-weak);
+  --status-critical-on:        var(--neg);
+  --status-info:               var(--cat2);
+  --status-info-container:     var(--cat2-weak);
+  --status-info-on:            var(--cat2);
+  --status-neutral:            var(--text-3);
+
+  /* ---- elevation → handoff shadows ---- */
+  --md-sys-elevation-1: var(--shadow);
+  --md-sys-elevation-2: var(--shadow-2);
+  --md-sys-elevation-3: var(--shadow-2);
+}
+
+/* ---- design-handoff tokens · DARK ---- */
+[data-theme="dark"] {
+  --bg:#0E1113; --surface:#1B1E20; --surface-2:#26292C; --track:#33373B;
+  --border:rgba(255,255,255,.10); --text:#E8EAED; --text-2:#BDC1C6; --text-3:#9AA0A6;
+  --primary:#7CC47F; --primary-strong:#9CD49E; --primary-weak:rgba(124,196,127,.16);
+  --on-primary:#0A2A0C; --primary-text:#9CD49E;
+  --pos:#81C995; --pos-weak:rgba(129,201,149,.14);
+  --neg:#F28B82; --neg-weak:rgba(242,139,130,.14);
+  --warn:#FDD663; --warn-weak:rgba(253,214,99,.14);
+  --cat2:#8AB4F8; --cat2-weak:rgba(138,180,248,.14);
+  --cat3:#4DB6AC; --cat4:#FDD663; --cat5:#9AA0A6;
+  --shadow:0 1px 2px rgba(0,0,0,.4),0 1px 3px rgba(0,0,0,.3);
+  --shadow-2:0 2px 6px rgba(0,0,0,.5),0 1px 3px rgba(0,0,0,.4);
+}
+
+/* ---- typography: Roboto UI, Roboto Mono for numeric fields ---- */
+html, body {
+  font-family: 'Roboto', -apple-system, 'Helvetica Neue', Arial, sans-serif;
+}

--- a/expenses.html
+++ b/expenses.html
@@ -11,6 +11,7 @@
 
     <!-- Wealth Suite shared shell -->
     <link rel="stylesheet" href="assets/suite.css?v=6">
+    <link rel="stylesheet" href="assets/theme.css?v=1">
     <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
     <script src="assets/suite-state.js?v=7" defer></script>
     <script src="assets/suite.js?v=11" defer></script>

--- a/golden_ratio_portfolio_dashboard.html
+++ b/golden_ratio_portfolio_dashboard.html
@@ -52,7 +52,7 @@ body{margin:0;font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-seri
 </style>
 
 <!-- Wealth Suite shared shell -->
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6">
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6"><link rel="stylesheet" href="assets/theme.css?v=1">
 <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
 <script src="assets/suite-state.js?v=7" defer></script>
 <script src="assets/suite.js?v=11" defer></script>

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap">
   <link rel="stylesheet" href="assets/suite.css?v=15">
+  <link rel="stylesheet" href="assets/theme.css?v=1">
 
   <!-- Apply theme before paint to avoid flash -->
   <script>

--- a/monte_carlo.html
+++ b/monte_carlo.html
@@ -105,7 +105,7 @@ body{font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-serif;backgro
 
 @media(max-width:600px){.main{padding:14px 16px}.hdr{padding:14px 16px}}
 </style>
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6">
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6"><link rel="stylesheet" href="assets/theme.css?v=1">
 <script src="https://d3js.org/d3.v7.min.js"></script>
 <script src="assets/suite-state.js?v=7" defer></script>
 <script src="assets/suite.js?v=11" defer></script>

--- a/net_worth.html
+++ b/net_worth.html
@@ -126,7 +126,7 @@ body{font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-serif;backgro
 </style>
 
 <!-- Wealth Suite shared shell -->
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6">
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6"><link rel="stylesheet" href="assets/theme.css?v=1">
 <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
 <script src="assets/suite-state.js?v=7" defer></script>
 <script src="assets/suite.js?v=11" defer></script>

--- a/portfolio_review.html
+++ b/portfolio_review.html
@@ -114,6 +114,7 @@ body{font-family:'Inter',sans-serif;background:var(--bg);color:var(--text);font-
 
 <!-- Wealth Suite shared shell -->
 <link rel="stylesheet" href="assets/suite.css?v=6">
+<link rel="stylesheet" href="assets/theme.css?v=1">
 <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
 <script src="assets/suite-state.js?v=7" defer></script>
 <script src="assets/suite.js?v=11" defer></script>

--- a/portfolio_tracker.html
+++ b/portfolio_tracker.html
@@ -11,6 +11,7 @@
 
     <!-- Wealth Suite shared shell -->
     <link rel="stylesheet" href="assets/suite.css?v=6">
+    <link rel="stylesheet" href="assets/theme.css?v=1">
     <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
     <script src="assets/suite-state.js?v=7" defer></script>
     <script src="assets/suite.js?v=11" defer></script>

--- a/retirement_master_plan_2.html
+++ b/retirement_master_plan_2.html
@@ -158,7 +158,7 @@ body{font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-serif;backgro
 </style>
 
 <!-- Wealth Suite shared shell -->
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6">
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6"><link rel="stylesheet" href="assets/theme.css?v=1">
 <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
 <script src="assets/suite-state.js?v=7" defer></script>
 <script src="assets/suite.js?v=11" defer></script>

--- a/roth_conversion.html
+++ b/roth_conversion.html
@@ -11,6 +11,7 @@
 
     <!-- Wealth Suite shared shell -->
     <link rel="stylesheet" href="assets/suite.css?v=6">
+    <link rel="stylesheet" href="assets/theme.css?v=1">
     <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
     <script src="assets/suite-state.js?v=7" defer></script>
     <script src="assets/suite.js?v=11" defer></script>

--- a/social_security.html
+++ b/social_security.html
@@ -112,7 +112,7 @@ input[type=range]::-moz-range-thumb{width:24px;height:24px;border-radius:50%;bac
 </style>
 
 <!-- Wealth Suite shared shell -->
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6">
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6"><link rel="stylesheet" href="assets/theme.css?v=1">
 <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
 <script src="assets/suite-state.js?v=7" defer></script>
 <script src="assets/suite.js?v=11" defer></script>


### PR DESCRIPTION
Step 1 of the design handoff (`design/Wealth-Suite/design_handoff_wealth_suite/README.md`): **apply the shared theme to all tool pages** so every page matches the Dashboard mockup.

## What changed
- **New `assets/theme.css`** — single source of truth for colour + type. Ships the handoff design tokens (`--bg` / `--surface` / `--primary` green `#2E7D32` / `--text`…, light + dark) and **remaps the legacy `--md-sys-color-*` / `--status-*` names onto them via `var()`**, so the injected shell topbar and every vanilla tool (which already consume those vars) repaint with no per-tool edits. Also `@import`s Roboto / Roboto Mono and sets the base UI font.
- **Wired into all 12 pages** (index + 11 tools), linked immediately *after* `suite.css` so it wins the equal-specificity `:root` cascade. Remaps reference the handoff tokens, so light/dark follows automatically — only the tokens are redefined for dark.
- Documented as "Phase 13 additions" in the cache-buster cadence log in `CLAUDE.md`.

## Scope (per agreed decisions)
- **Shared token layer + wiring** (foundation), and **replace MD3 with the handoff palette**.
- **Deferred:** the 5 Tailwind tools (portfolio_tracker, expenses, TaxEstimatorV5, roth_conversion, TaxAssetCalcv4) pick up the shared topbar + page chrome only; their internal utility-class colours still need the pixel-perfect reskin (handoff steps 2–4).

## Verified (headless Chrome, served locally)
- **Dashboard** — green logo/buttons, `#F1F3F4` bg, white cards, Roboto. ✓
- **Net Worth** (vanilla) — green title, green active-tab underline, correct surfaces/borders. ✓
- **Portfolio Tracker** (Tailwind) — adopts shared topbar + page chrome; internal controls still Tailwind blue (expected). ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)