### PR TITLE
Single-window navigation: tools open inside the persistent shell

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,8 +225,27 @@ Phase 13b (app-shell rebuild — the new Dashboard home):
   Hub") until step 2 wires them.
 - Site Map / Data Hub / Settings render as visible but non-navigating
   "Soon" items until handoff steps 2–3 build those pages.
-- Follow-up: unify the tool pages into the same sidebar shell (currently
-  they keep suite.js's horizontal topnav).
+
+Phase 13c (single-window navigation — tools open inside the shell):
+- `index.html` gained a hash-based router: clicking any in-suite tool
+  link loads that tool into a full-height `<iframe id="ws-frame">` inside
+  the persistent shell, so the sidebar + top bar **never reload** and the
+  collapse state truly stays put during navigation. Route = `#<file.html>`
+  (deep-linkable, native back/forward via `hashchange`). Top bar swaps to
+  "← Dashboard · <tool title> · New tab ↗" when a tool is open. A
+  delegated `click` handler routes any `a[href$=".html"]` that maps to a
+  known tool (sidebar items, dashboard cross-link chips, the tax-alert
+  CTA); Cmd/Ctrl/middle-click and the "New tab" chip still open the tool
+  standalone.
+- `assets/suite.js?v=12` (ALL tool pages — bumped from v=11): now
+  detects when it is embedded (`window.self !== window.top`) and, if so,
+  **skips its own topnav injection** and zeroes `body.paddingTop` so the
+  tool renders flush inside the shell with no double chrome / no gap.
+  Also added a `storage` listener so a theme change in the shell (or any
+  tab) re-applies live in the embedded tool. index.html still does NOT
+  load suite.js.
+- Follow-up: the tool pages still work standalone (opened directly, they
+  render their own topnav as before) — only the embedded case changes.
 
 ## Constraints to preserve
 

--- a/TaxAssetCalcv4.html
+++ b/TaxAssetCalcv4.html
@@ -36,7 +36,7 @@
     <link rel="stylesheet" href="assets/theme.css?v=1">
     <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
     <script src="assets/suite-state.js?v=7" defer></script>
-    <script src="assets/suite.js?v=11" defer></script>
+    <script src="assets/suite.js?v=12" defer></script>
     <script src="assets/adapters/asset.js?v=5" defer></script>
 </head>
 <body class="bg-gray-100 flex items-center justify-center min-h-screen py-8">

--- a/TaxEstimatorV5.html
+++ b/TaxEstimatorV5.html
@@ -21,7 +21,7 @@
   <link rel="stylesheet" href="assets/theme.css?v=1">
   <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
   <script src="assets/suite-state.js?v=7" defer></script>
-  <script src="assets/suite.js?v=11" defer></script>
+  <script src="assets/suite.js?v=12" defer></script>
   <script src="assets/adapters/tax.js?v=5" defer></script>
 </head>
 <body class="bg-slate-50">

--- a/assets/suite.js
+++ b/assets/suite.js
@@ -112,8 +112,23 @@
     if (readPreference() === 'system') applyTheme();
   });
 
+  // Keep theme in sync when another document (e.g. the app-shell that
+  // embeds this page in an iframe, or another tab) changes the
+  // preference. `storage` fires in every OTHER same-origin document.
+  window.addEventListener('storage', (e) => {
+    if (e.key === STORAGE_KEY) applyTheme();
+  });
+
   // Apply ASAP — before paint where possible
   applyTheme();
+
+  // Are we embedded inside the Wealth Suite app shell (index.html)?
+  // When so, the shell already renders the sidebar + top bar, so this
+  // page must NOT inject its own topnav (would double up) and must drop
+  // the top padding it reserves for that topnav.
+  function isEmbedded() {
+    try { return window.self !== window.top; } catch (e) { return true; }
+  }
 
   // ---------- Topbar injection ----------
   function currentModuleHref() {
@@ -245,6 +260,13 @@
   }
 
   function injectTopbarIfMissing() {
+    // Embedded in the app shell → shell owns the chrome. Skip the
+    // topnav and remove the reserved top padding so the tool sits flush.
+    if (isEmbedded()) {
+      document.documentElement.setAttribute('data-suite-embedded', 'true');
+      try { document.body.style.paddingTop = '0'; } catch (e) {}
+      return;
+    }
     // Phase 8: JS is the single source of truth for the topbar.
     // If a static topbar exists (dashboard renders one for no-flash
     // initial paint), replace it in place with the built version so

--- a/expenses.html
+++ b/expenses.html
@@ -14,7 +14,7 @@
     <link rel="stylesheet" href="assets/theme.css?v=1">
     <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
     <script src="assets/suite-state.js?v=7" defer></script>
-    <script src="assets/suite.js?v=11" defer></script>
+    <script src="assets/suite.js?v=12" defer></script>
     <script src="assets/adapters/expenses.js?v=1" defer></script>
 </head>
 <body class="bg-gray-100 min-h-screen">

--- a/golden_ratio_portfolio_dashboard.html
+++ b/golden_ratio_portfolio_dashboard.html
@@ -55,7 +55,7 @@ body{margin:0;font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-seri
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6"><link rel="stylesheet" href="assets/theme.css?v=1">
 <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
 <script src="assets/suite-state.js?v=7" defer></script>
-<script src="assets/suite.js?v=11" defer></script>
+<script src="assets/suite.js?v=12" defer></script>
 <script src="assets/adapters/golden.js?v=2" defer></script>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -103,8 +103,17 @@
     .ws-profile__name { font-size: 12px; font-weight: 500; color: var(--text); line-height: 1.2; }
     .ws-profile__sub { font-size: 10px; color: var(--text-2); line-height: 1.2; }
 
-    /* ---- Scrollable content ---- */
-    .ws-content { flex: 1; overflow-y: auto; padding: 24px 28px 40px; animation: ws-fade .4s ease; }
+    /* ---- Top-bar nav cluster (back / title / new-tab) ---- */
+    .ws-topbar__nav { display: flex; align-items: center; gap: 10px; }
+    .ws-back { display: inline-flex; align-items: center; gap: 6px; padding: 7px 13px; border-radius: 24px; cursor: pointer; color: var(--text-2); font-size: 12.5px; font-weight: 500; border: 1px solid var(--border); background: none; font-family: inherit; }
+    .ws-back:hover { color: var(--text); border-color: var(--primary); }
+    .ws-newtab { display: inline-flex; align-items: center; gap: 5px; padding: 6px 12px; border-radius: 20px; background: var(--surface-2); border: 1px solid var(--border); font-size: 11px; color: var(--text-2); text-decoration: none; }
+    .ws-newtab:hover { color: var(--text); border-color: var(--primary); }
+
+    /* ---- Scrollable content + embedded tool frame ---- */
+    .ws-content { flex: 1; display: flex; flex-direction: column; overflow-y: auto; padding: 24px 28px 40px; animation: ws-fade .4s ease; }
+    .ws-content.is-tool { padding: 0; overflow: hidden; }
+    .ws-frame { flex: 1 1 auto; width: 100%; height: 100%; border: 0; background: var(--surface); display: block; }
     @keyframes ws-fade { from { opacity: 0; } to { opacity: 1; } }
     @keyframes ws-draw { from { stroke-dashoffset: 900; } to { stroke-dashoffset: 0; } }
     @keyframes ws-pulse { 0%,100% { opacity: .4; } 50% { opacity: 1; } }
@@ -314,9 +323,19 @@
       <button class="ws-hamburger" id="ws-hamburger" type="button" title="Toggle sidebar" aria-label="Toggle sidebar">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
       </button>
-      <span class="ws-pagetitle">Dashboard</span>
-      <span class="ws-sep">·</span>
-      <span class="ws-date" id="ws-date">—</span>
+      <div class="ws-topbar__nav">
+        <button class="ws-back" id="ws-back" type="button" hidden title="Back to Dashboard">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="19" y1="12" x2="5" y2="12"></line><polyline points="12 19 5 12 12 5"></polyline></svg>
+          Dashboard
+        </button>
+        <span class="ws-pagetitle" id="ws-title">Dashboard</span>
+        <span class="ws-sep" id="ws-datesep">·</span>
+        <span class="ws-date" id="ws-date">—</span>
+        <a class="ws-newtab" id="ws-newtab" hidden target="_blank" rel="noopener" title="Open in a new tab">
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
+          New tab
+        </a>
+      </div>
       <div class="ws-topbar__spacer"></div>
 
       <button class="ws-themebtn" id="ws-theme" type="button" title="Cycle theme: system → light → dark">
@@ -343,7 +362,8 @@
       </div>
     </header>
 
-    <div class="ws-content">
+    <div class="ws-content" id="ws-content">
+      <div id="ws-dash-view">
       <div class="ws-dash">
 
         <!-- ═══ PAGE HEADER ═══ -->
@@ -634,6 +654,8 @@
         <span>Wealth Suite — runs entirely in your browser. No tracking, no upload.</span>
         <span>Sample figures shown · live data arrives with the Data Hub</span>
       </footer>
+      </div><!-- /#ws-dash-view -->
+      <iframe id="ws-frame" class="ws-frame" title="Tool" hidden></iframe>
     </div>
   </div>
 </div>
@@ -655,6 +677,96 @@
       if (collapsed) root.removeAttribute('data-ws-collapsed'); else root.setAttribute('data-ws-collapsed', '1');
       writeNav({ collapsed: !collapsed });
     });
+
+    // ---- Single-window router: tools open inside the shell iframe so
+    // the sidebar + top bar never reload. Hash-based (#tool.html) for
+    // deep-linking + native back/forward. Cmd/Ctrl-click or the "New
+    // tab" chip still opens a tool standalone. ----
+    var ROUTES = {
+      'net_worth.html': 'Net Worth',
+      'portfolio_tracker.html': 'Portfolio Tracker',
+      'expenses.html': 'Expenses',
+      'retirement_master_plan_2.html': 'Retirement Plan',
+      'TaxEstimatorV5.html': 'Tax Plan (Estimator)',
+      'roth_conversion.html': 'Roth Conversion',
+      'social_security.html': 'Social Security',
+      'TaxAssetCalcv4.html': 'Asset & Cap-Gains',
+      'portfolio_review.html': 'Portfolio Review',
+      'golden_ratio_portfolio_dashboard.html': 'Golden φ Portfolio',
+      'monte_carlo.html': 'Monte Carlo'
+    };
+    var frame = document.getElementById('ws-frame');
+    var dashView = document.getElementById('ws-dash-view');
+    var content = document.getElementById('ws-content');
+    var titleEl = document.getElementById('ws-title');
+    var backEl = document.getElementById('ws-back');
+    var dateSep = document.getElementById('ws-datesep');
+    var newtabEl = document.getElementById('ws-newtab');
+    var navItems = Array.prototype.slice.call(document.querySelectorAll('.ws-navitem[href]'));
+
+    function fileFromHref(href) {
+      if (!href) return '';
+      var clean = href.split('#')[0].split('?')[0].split('/');
+      return clean[clean.length - 1];
+    }
+    function setActive(file) {
+      navItems.forEach(function (a) {
+        var on = file ? (fileFromHref(a.getAttribute('href')) === file)
+                      : (fileFromHref(a.getAttribute('href')) === 'index.html');
+        a.classList.toggle('is-active', on);
+        if (on) a.setAttribute('aria-current', 'page'); else a.removeAttribute('aria-current');
+      });
+    }
+    function showDashboard() {
+      if (frame) { frame.hidden = true; frame.removeAttribute('src'); }
+      if (dashView) dashView.hidden = false;
+      if (content) content.classList.remove('is-tool');
+      if (backEl) backEl.hidden = true;
+      if (newtabEl) newtabEl.hidden = true;
+      if (dateSep) dateSep.hidden = false;
+      var d = document.getElementById('ws-date'); if (d) d.hidden = false;
+      if (titleEl) titleEl.textContent = 'Dashboard';
+      document.title = 'Wealth Suite — Dashboard';
+      setActive(null);
+    }
+    function showTool(file) {
+      var title = ROUTES[file];
+      if (!title) { showDashboard(); return; }
+      if (dashView) dashView.hidden = true;
+      if (content) content.classList.add('is-tool');
+      if (frame) { if (frame.getAttribute('src') !== file) frame.setAttribute('src', file); frame.hidden = false; frame.setAttribute('title', title); }
+      if (backEl) backEl.hidden = false;
+      if (dateSep) dateSep.hidden = true;
+      var d = document.getElementById('ws-date'); if (d) d.hidden = true;
+      if (newtabEl) { newtabEl.hidden = false; newtabEl.setAttribute('href', file); }
+      if (titleEl) titleEl.textContent = title;
+      document.title = 'Wealth Suite — ' + title;
+      setActive(file);
+    }
+    function currentFile() {
+      var h = fileFromHref((location.hash || '').replace(/^#/, ''));
+      return ROUTES[h] ? h : '';
+    }
+    function route() {
+      var f = currentFile();
+      if (f) showTool(f); else showDashboard();
+      if (content) content.scrollTop = 0;
+    }
+    function navigate(file) {
+      var target = (file && ROUTES[file]) ? ('#' + file) : '#';
+      if (location.hash === target) route(); else location.hash = target;
+    }
+    window.addEventListener('hashchange', route);
+    document.body.addEventListener('click', function (e) {
+      if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+      var a = e.target.closest && e.target.closest('a[href]');
+      if (!a || a.target === '_blank') return;
+      var file = fileFromHref(a.getAttribute('href'));
+      if (file === 'index.html') { e.preventDefault(); navigate(''); }
+      else if (ROUTES[file]) { e.preventDefault(); navigate(file); }
+    });
+    if (backEl) backEl.addEventListener('click', function () { navigate(''); });
+    route();
 
     // ---- Theme cycle (system → light → dark), shared preference key ----
     var TKEY = 'wealthSuite.themePreference';

--- a/monte_carlo.html
+++ b/monte_carlo.html
@@ -108,7 +108,7 @@ body{font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-serif;backgro
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6"><link rel="stylesheet" href="assets/theme.css?v=1">
 <script src="https://d3js.org/d3.v7.min.js"></script>
 <script src="assets/suite-state.js?v=7" defer></script>
-<script src="assets/suite.js?v=11" defer></script>
+<script src="assets/suite.js?v=12" defer></script>
 <script src="assets/adapters/mc.js?v=1" defer></script>
 </head>
 <body>

--- a/net_worth.html
+++ b/net_worth.html
@@ -129,7 +129,7 @@ body{font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-serif;backgro
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6"><link rel="stylesheet" href="assets/theme.css?v=1">
 <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
 <script src="assets/suite-state.js?v=7" defer></script>
-<script src="assets/suite.js?v=11" defer></script>
+<script src="assets/suite.js?v=12" defer></script>
 <script src="assets/adapters/networth.js?v=1" defer></script>
 </head>
 <body>

--- a/portfolio_review.html
+++ b/portfolio_review.html
@@ -117,7 +117,7 @@ body{font-family:'Inter',sans-serif;background:var(--bg);color:var(--text);font-
 <link rel="stylesheet" href="assets/theme.css?v=1">
 <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
 <script src="assets/suite-state.js?v=7" defer></script>
-<script src="assets/suite.js?v=11" defer></script>
+<script src="assets/suite.js?v=12" defer></script>
 <script src="assets/adapters/portfolio.js?v=6" defer></script>
 </head>
 <body>

--- a/portfolio_tracker.html
+++ b/portfolio_tracker.html
@@ -14,7 +14,7 @@
     <link rel="stylesheet" href="assets/theme.css?v=1">
     <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
     <script src="assets/suite-state.js?v=7" defer></script>
-    <script src="assets/suite.js?v=11" defer></script>
+    <script src="assets/suite.js?v=12" defer></script>
     <script src="assets/adapters/tracker.js?v=1" defer></script>
 </head>
 <body class="bg-gray-100 min-h-screen">

--- a/retirement_master_plan_2.html
+++ b/retirement_master_plan_2.html
@@ -161,7 +161,7 @@ body{font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-serif;backgro
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6"><link rel="stylesheet" href="assets/theme.css?v=1">
 <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
 <script src="assets/suite-state.js?v=7" defer></script>
-<script src="assets/suite.js?v=11" defer></script>
+<script src="assets/suite.js?v=12" defer></script>
 <script src="assets/adapters/retirement.js?v=6" defer></script>
 </head>
 <body>

--- a/roth_conversion.html
+++ b/roth_conversion.html
@@ -14,7 +14,7 @@
     <link rel="stylesheet" href="assets/theme.css?v=1">
     <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
     <script src="assets/suite-state.js?v=7" defer></script>
-    <script src="assets/suite.js?v=11" defer></script>
+    <script src="assets/suite.js?v=12" defer></script>
     <script src="assets/adapters/roth.js?v=1" defer></script>
 </head>
 <body class="bg-gray-100 min-h-screen">

--- a/social_security.html
+++ b/social_security.html
@@ -115,7 +115,7 @@ input[type=range]::-moz-range-thumb{width:24px;height:24px;border-radius:50%;bac
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6"><link rel="stylesheet" href="assets/theme.css?v=1">
 <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
 <script src="assets/suite-state.js?v=7" defer></script>
-<script src="assets/suite.js?v=11" defer></script>
+<script src="assets/suite.js?v=12" defer></script>
 <script src="assets/adapters/ss.js?v=1" defer></script>
 </head>
 <body>


### PR DESCRIPTION
Delivers the "open individual pages in the same window with the collapsible side panel staying put during navigation" UX.

## What changed
- **`index.html` hash router**: clicking any in-suite tool link loads that tool into a full-height `<iframe>` inside the shell, so the **sidebar + top bar never reload** and the collapse state truly persists across navigation. Routes are `#<file.html>` — deep-linkable, with native back/forward via `hashchange`. Top bar swaps to **← Dashboard · <tool> · New tab ↗** when a tool is open.
- A delegated click handler routes sidebar items, dashboard cross-link chips, and the tax-alert CTA. **Cmd/Ctrl/middle-click and the "New tab" chip** still open a tool standalone in a new tab.
- **`assets/suite.js` v=11 → v=12** (all 11 tool pages): detects when it's embedded (`window.self !== window.top`) and then **skips its own topnav injection** and zeroes `body.padding-top`, so an embedded tool renders flush with no double chrome / no gap. Added a `storage` listener so a theme change in the shell re-applies live in the embedded tool. `index.html` still does not load suite.js.

## Verified
Deep-linked `index.html#net_worth.html` in headless Chrome: sidebar persists with Net Worth active, top bar shows ← Dashboard · Net Worth · New tab, tool renders flush in the iframe (no double topnav, no gap). Tool pages still render their own topnav when opened standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)