### PR TITLE
Fix mobile sidebar drawer + wire dashboard KPI tiles to store (step 4 start)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,6 +313,27 @@ Phase 13e (Settings — handoff step 3):
   `fedBracket`, active-scenario assumptions, and the alert thresholds;
   and surfacing the active scenario name in the top-bar profile chip.
 
+Phase 13f (mobile drawer fix + step 4 start — KPI wiring):
+- **Mobile sidebar drawer** (index.html): below 860px the sidebar was
+  `position:absolute` and covered the top-bar hamburger, so it couldn't
+  be tapped. Now the sidebar is an off-canvas drawer (`transform:
+  translateX(-100%)`); the hamburger toggles `.ws-shell.is-mobnav-open`
+  (mobile) vs `data-ws-collapsed` (desktop, unchanged), a `#ws-backdrop`
+  dismisses it, and navigating or resizing to desktop closes it. Labels
+  stay visible in the drawer even if the collapse flag is set.
+- **Step 4 (first slice) — live KPI tiles**: index.html now computes
+  Total Net Worth (`portfolio.totalValue` + `otherAssets` + retirement
+  balances − liabilities), Investment Portfolio, and Monthly Spending
+  (current-month `expenses.transactions` vs summed category budgets)
+  from the store and fills the `data-ws-metric` tiles, flipping the
+  subline note to "live from your data". An empty store keeps the
+  illustrative sample. Reactively re-renders via `store.subscribe`.
+  Retirement Readiness and the Net-Worth-Growth / Allocation charts are
+  still illustrative — next slice (they need history / a computed layer).
+- Step 4 remaining: charts + readiness from real data; refactor each
+  tool to READ the hub (holdings/accounts/household/scenario/prefs)
+  instead of its own inputs.
+
 ## Constraints to preserve
 
 - **Zero build step.** No Vite/Webpack until scope demands it.

--- a/index.html
+++ b/index.html
@@ -226,13 +226,37 @@
     .ws-alert__dismiss:hover { color: var(--text); }
 
     @media (max-width: 1100px) { .ws-charts, .ws-planning { grid-template-columns: 1fr; } .ws-kpis { grid-template-columns: repeat(2, 1fr); } }
-    @media (max-width: 860px) { .ws-sidebar { position: absolute; z-index: 20; height: 100vh; box-shadow: var(--shadow-2); } }
-    @media (max-width: 620px) { .ws-kpis { grid-template-columns: 1fr; } }
+
+    /* Mobile: the sidebar becomes an off-canvas drawer so it never covers
+       the top-bar hamburger. The hamburger toggles `.is-mobnav-open` on the
+       shell; a backdrop dismisses it. Collapse (72px rail) is desktop-only. */
+    .ws-backdrop { display: none; }
+    @media (max-width: 860px) {
+      .ws-sidebar {
+        position: fixed; top: 0; left: 0; height: 100vh; z-index: 40;
+        width: 240px !important; min-width: 240px !important;
+        transform: translateX(-100%); transition: transform .25s ease;
+        box-shadow: var(--shadow-2);
+      }
+      .ws-shell.is-mobnav-open .ws-sidebar { transform: translateX(0); }
+      /* keep labels visible in the drawer even if collapse flag is set */
+      html[data-ws-collapsed="1"] .sb-x { display: revert !important; }
+      html[data-ws-collapsed="1"] .ws-navitem,
+      html[data-ws-collapsed="1"] .ws-datahub,
+      html[data-ws-collapsed="1"] .ws-logo__row,
+      html[data-ws-collapsed="1"] .ws-sidefoot__row { justify-content: flex-start; }
+      .ws-backdrop { display: block; position: fixed; inset: 0; background: rgba(0,0,0,.45); z-index: 35; opacity: 0; visibility: hidden; transition: opacity .25s ease; }
+      .ws-shell.is-mobnav-open .ws-backdrop { opacity: 1; visibility: visible; }
+    }
+    @media (max-width: 620px) { .ws-kpis { grid-template-columns: 1fr; } .ws-content { padding: 20px 16px 40px; } .ws-importbtn, .ws-profile .sb-x { display: none; } }
   </style>
 </head>
 <body class="suite-body">
 
 <div class="ws-shell">
+
+  <!-- Mobile drawer backdrop (only visible ≤860px when the drawer is open) -->
+  <div class="ws-backdrop" id="ws-backdrop" aria-hidden="true"></div>
 
   <!-- ██████████████  SIDEBAR  ██████████████ -->
   <aside class="ws-sidebar">
@@ -389,7 +413,7 @@
         <div class="ws-pagehead">
           <div>
             <div class="ws-greeting" id="ws-greeting">Welcome back 👋</div>
-            <div class="ws-subline">Wealth snapshot · <strong id="ws-hh">Your household</strong> · <span style="color:var(--warn);">sample figures — connect accounts in the Data Hub</span></div>
+            <div class="ws-subline">Wealth snapshot · <strong id="ws-hh">Your household</strong> · <span id="ws-sample-note" style="color:var(--warn);">sample figures — connect accounts in the Data Hub</span></div>
           </div>
           <div style="display:flex; gap:10px;">
             <button class="ws-btn-outline" type="button" title="Customize dashboard — coming soon">
@@ -687,15 +711,23 @@
     'use strict';
     var root = document.documentElement;
 
-    // ---- Sidebar collapse (persisted in ws-shell-nav) ----
+    // ---- Sidebar: desktop = collapse (240↔72, persisted); mobile
+    // (≤860px) = off-canvas drawer toggled by the same hamburger. ----
     var hb = document.getElementById('ws-hamburger');
+    var shellEl = document.querySelector('.ws-shell');
+    var backdrop = document.getElementById('ws-backdrop');
+    var mqMobile = window.matchMedia('(max-width: 860px)');
+    function closeMobNav() { if (shellEl) shellEl.classList.remove('is-mobnav-open'); }
     function readNav() { try { return JSON.parse(localStorage.getItem('ws-shell-nav') || '{}'); } catch (e) { return {}; } }
     function writeNav(patch) { var n = readNav(); Object.assign(n, patch); try { localStorage.setItem('ws-shell-nav', JSON.stringify(n)); } catch (e) {} }
     if (hb) hb.addEventListener('click', function () {
+      if (mqMobile.matches) { if (shellEl) shellEl.classList.toggle('is-mobnav-open'); return; }
       var collapsed = root.getAttribute('data-ws-collapsed') === '1';
       if (collapsed) root.removeAttribute('data-ws-collapsed'); else root.setAttribute('data-ws-collapsed', '1');
       writeNav({ collapsed: !collapsed });
     });
+    if (backdrop) backdrop.addEventListener('click', closeMobNav);
+    mqMobile.addEventListener('change', function () { if (!mqMobile.matches) closeMobNav(); });
 
     // ---- Single-window router: tools open inside the shell iframe so
     // the sidebar + top bar never reload. Hash-based (#tool.html) for
@@ -772,6 +804,7 @@
       var f = currentFile();
       if (f) showTool(f); else showDashboard();
       if (content) content.scrollTop = 0;
+      closeMobNav();
     }
     function navigate(file) {
       var target = (file && ROUTES[file]) ? ('#' + file) : '#';
@@ -918,11 +951,72 @@
         set('ws-avatar', ini);
       } catch (e) {}
     }
+    // ---- Step 4: live KPI tiles from the store (Data Hub feeds these).
+    // When the store has real figures we replace the sample placeholders
+    // in the Net Worth / Investment Portfolio / Monthly Spending tiles;
+    // an empty store keeps the illustrative sample. (Retirement Readiness
+    // and the charts stay illustrative until a later slice.) ----
+    function money(n) { n = Number(n) || 0; var a = Math.abs(n); if (a >= 1e6) return '$' + (n / 1e6).toFixed(2) + 'M'; if (a >= 1e3) return '$' + Math.round(n / 1e3) + 'K'; return '$' + Math.round(n); }
+    function full(n) { return '$' + Math.round(Number(n) || 0).toLocaleString('en-US'); }
+    function metricEl(m) { return document.querySelector('[data-ws-metric="' + m + '"]'); }
+    function refreshKPIs() {
+      try {
+        var store = window.WealthSuite && window.WealthSuite.store;
+        if (!store) return;
+        var s = store.export();
+        var holdings = (s.portfolio && s.portfolio.holdings) || [];
+        var portfolioVal = Number(s.portfolio && s.portfolio.totalValue) ||
+          holdings.reduce(function (t, h) { return t + (Number(h.currentPrice) > 0 ? Number(h.currentPrice) * Number(h.shares) : (Number(h.costBasis) || 0)); }, 0);
+        var otherAssets = ((s.otherAssets) || []).reduce(function (t, a) { return t + (Number(a.value) || 0); }, 0);
+        var retire = Number(s.retirement && s.retirement.balances && s.retirement.balances.total) || 0;
+        var liabItems = (s.liabilities && s.liabilities.items) || [];
+        var liab = Number(s.liabilities && s.liabilities.total) || liabItems.reduce(function (t, l) { return t + (Number(l.balance) || 0); }, 0);
+        var netWorth = portfolioVal + otherAssets + retire - liab;
+
+        var tx = (s.expenses && s.expenses.transactions) || [];
+        var d0 = new Date(); var ym = d0.getFullYear() + '-' + String(d0.getMonth() + 1).padStart(2, '0');
+        var monthSpend = tx.reduce(function (t, r) {
+          var dt = r && (r.date || r.at); if (!dt) return t;
+          if (String(dt).slice(0, 7) !== ym) return t;
+          var amt = Number(r.amount) || 0;
+          return t + (amt < 0 ? -amt : (r.type === 'expense' ? amt : 0));
+        }, 0);
+        var budget = ((s.expenses && s.expenses.categories) || []).reduce(function (t, c) { return t + (Number(c.budgetMonthly) || 0); }, 0);
+
+        var hasData = holdings.length > 0 || otherAssets > 0 || liab > 0 || portfolioVal > 0 || monthSpend > 0;
+        var note = document.getElementById('ws-sample-note');
+        if (!hasData) { if (note) { note.textContent = 'sample figures — connect accounts in the Data Hub'; note.style.color = 'var(--warn)'; } return; }
+        if (note) { note.textContent = 'live from your data'; note.style.color = 'var(--pos)'; }
+
+        var nw = metricEl('netWorth');
+        if (nw) {
+          nw.querySelector('.ws-kpi__big').textContent = money(netWorth);
+          nw.querySelector('.ws-kpi__sub').textContent = full(netWorth);
+          nw.querySelector('.ws-kpi__foot').innerHTML = '<span class="ws-hint">Assets − liabilities</span><span class="ws-hint">' + money(portfolioVal + otherAssets + retire) + ' assets</span>';
+        }
+        var pf = metricEl('portfolio');
+        if (pf) {
+          pf.querySelector('.ws-kpi__big').textContent = money(portfolioVal);
+          pf.querySelector('.ws-kpi__sub').textContent = full(portfolioVal);
+          pf.querySelector('.ws-kpi__foot').innerHTML = '<span class="ws-hint">' + holdings.length + ' holding' + (holdings.length === 1 ? '' : 's') + '</span><span class="ws-hint">Portfolio Tracker</span>';
+        }
+        var sp = metricEl('monthlySpending');
+        if (sp) {
+          sp.querySelector('.ws-kpi__big').textContent = full(monthSpend);
+          var pct = budget ? Math.min(100, monthSpend / budget * 100) : 0;
+          var hint = sp.querySelector('.ws-hint'); if (hint) hint.textContent = budget ? ('of ' + full(budget) + ' budget · ' + pct.toFixed(1) + '%') : 'this month';
+          var meter = sp.querySelector('.ws-meter > i'); if (meter) meter.style.width = (budget ? pct : 0) + '%';
+          sp.querySelector('.ws-kpi__foot').innerHTML = '<span style="font-size:11px;color:var(--pos);font-weight:500;">' + (budget ? (full(Math.max(0, budget - monthSpend)) + ' remaining') : 'no budget set') + '</span><span class="ws-hint">this month</span>';
+        }
+      } catch (e) {}
+    }
+    function refreshAll() { refreshProfile(); refreshKPIs(); }
+
     if (window.WealthSuite && window.WealthSuite.store) {
-      refreshProfile();
-      try { window.WealthSuite.store.subscribe(refreshProfile); } catch (e) {}
+      refreshAll();
+      try { window.WealthSuite.store.subscribe(refreshAll); } catch (e) {}
     } else {
-      window.addEventListener('DOMContentLoaded', function () { setTimeout(refreshProfile, 0); });
+      window.addEventListener('DOMContentLoaded', function () { setTimeout(refreshAll, 0); });
     }
   })();
 </script>


### PR DESCRIPTION
Two things: fixes the mobile sidebar (you couldn't tap the hamburger on a phone), and starts **step 4** by making the dashboard KPI tiles show real store data.

## Mobile drawer fix
Below 860px the sidebar was `position:absolute` and sat on top of the top-bar hamburger, so it couldn't be tapped. It's now an **off-canvas drawer** (`translateX(-100%)`):
- The hamburger toggles `.ws-shell.is-mobnav-open` on mobile (vs `data-ws-collapsed` on desktop, unchanged).
- A `#ws-backdrop` dismisses it; navigating or resizing to desktop closes it; labels stay visible in the drawer.

Verified in headless Chrome at 390px: hamburger is visible with the sidebar off-canvas, and tapping it slides the drawer in over a dimmed backdrop.

## Step 4 (first slice) — live KPI tiles
The dashboard now computes from the store and fills the `data-ws-metric` tiles:
- **Total Net Worth** = `portfolio.totalValue` + `otherAssets` + retirement balances − liabilities
- **Investment Portfolio** = `portfolio.totalValue` (+ holdings count)
- **Monthly Spending** = this month's `expenses.transactions` vs summed category budgets (with meter + remaining)

The subline flips to **"live from your data"**; an **empty store keeps the illustrative sample**. Re-renders reactively via `store.subscribe`.

Verified: seeding a store (holdings + other assets + liabilities + expenses) shows **Net Worth $3.84M**, **Portfolio $2.18M** (2 holdings), **Spending $2,000 of $4,300 budget**, subline "live from your data".

## Still illustrative (next slices)
Retirement Readiness and the Net-Worth-Growth / Allocation charts (need history / a computed layer), and refactoring each **tool** to read the hub instead of its own inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)