### PR TITLE
Step 4 slice 2: fix hub↔tool data contract (per-share costBasis, ids, liability type)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,6 +334,39 @@ Phase 13f (mobile drawer fix + step 4 start — KPI wiring):
   tool to READ the hub (holdings/accounts/household/scenario/prefs)
   instead of its own inputs.
 
+Phase 13g (step 4 slice 2 — hub↔tool data contract):
+- **`holding.costBasis` is PER-SHARE** — that's the store convention set
+  by the Portfolio Tracker (its CSV import divides Vanguard "…Total"
+  columns by shares; Fidelity/Schwab/generic cost headers are already
+  per-share, and its table edits/valuations all assume per-share). The
+  Data Hub originally committed lot TOTALS into the same field, which
+  would have over-valued hub-imported holdings by ~shares× in the
+  tracker. Fixed in data_hub.html:
+  - `parseCSV()` mirrors the tracker rule (header contains /total/i →
+    divide by shares) and commits per-share `costBasis`.
+  - Preview still displays the lot total (mockup style); paste
+    placeholder + hint now show per-share examples.
+  - New hub-committed holdings get an `id` (`TICKER-ts-rand`) — the
+    tracker keys row edit/delete/quote-merge on `h.id`, so id-less rows
+    would mis-target edits.
+  - `holdingValue()` helper (= (currentPrice||costBasis)×shares) now
+    used by acctValue/recompute/net-of-liabilities; same fix applied to
+    the dashboard KPI fallback in index.html.
+  - Hub liability form gained a `type` select matching net_worth's
+    options (mortgage/auto/student/credit/other) — rows previously
+    rendered "undefined" type in Net Worth.
+- Verified end-to-end (headless): hub paste of generic per-share CSV +
+  Vanguard-style "Cost Basis Total" CSV → store holds cb=165.34 / cb=50
+  with ids; Portfolio Tracker mounts them, renders both rows correctly,
+  re-syncs totalValue=24840.8. Hub-entered Home $680K + Mortgage $312K
+  → Net Worth shows assets $680K / liab $312K / net worth $368K (matches
+  hub's "Net of liabilities").
+- Tracker/Net Worth are hub-fed now (tracker reads `portfolio.holdings`
+  on mount; net_worth reads the `assets.*` mirror + `liabilities.items`
+  and subscribes). Tracker still has its own CSV import + doesn't
+  live-subscribe to store changes while open — acceptable in the shell
+  (iframe remounts per navigation).
+
 ## Constraints to preserve
 
 - **Zero build step.** No Vite/Webpack until scope demands it.

--- a/data_hub.html
+++ b/data_hub.html
@@ -196,9 +196,9 @@
         <input type="file" id="dh-file" accept=".csv,text/csv" hidden>
         <button class="dh-paste" id="dh-paste-toggle" type="button">Paste rows instead</button>
         <textarea class="dh-textarea" id="dh-paste-area" hidden placeholder="Ticker,Shares,Cost Basis,Account
-VTI,120,198400,Fidelity Brokerage
-AAPL,50,41900,Schwab 401(k)"></textarea>
-        <div class="dh-hint" style="line-height:1.5;">Accepted columns: Ticker, Shares, Cost Basis, Account, Date. Fidelity / Schwab / Vanguard headers auto-map; extra columns are ignored.</div>
+VTI,120,165.34,Fidelity Brokerage
+AAPL,50,142.80,Schwab 401(k)"></textarea>
+        <div class="dh-hint" style="line-height:1.5;">Accepted columns: Ticker, Shares, Cost Basis (per share; "…Total" headers auto-divide), Account, Date. Fidelity / Schwab / Vanguard headers auto-map; extra columns are ignored.</div>
       </div>
       <div class="dh-preview" id="dh-preview">
         <div class="dh-empty">Drop or paste a CSV to preview holdings before committing.</div>
@@ -266,6 +266,7 @@ AAPL,50,41900,Schwab 401(k)"></textarea>
       <div class="dh-list" id="dh-liab-rows"></div>
       <form class="dh-form" id="dh-liab-form" hidden autocomplete="off">
         <input name="name" placeholder="e.g. Mortgage" style="min-width:140px;" required>
+        <select name="type"><option value="mortgage">Mortgage</option><option value="auto">Auto loan</option><option value="student">Student loan</option><option value="credit">Credit card</option><option value="other">Other</option></select>
         <input name="rate" placeholder="Rate %" style="width:74px;">
         <input name="balance" placeholder="Balance $" inputmode="numeric" style="width:110px;" required>
         <button class="dh-btn-primary" type="submit" style="padding:7px 14px;">Add</button>
@@ -332,9 +333,15 @@ AAPL,50,41900,Schwab 401(k)"></textarea>
     function otherAssets() { return store.get('otherAssets') || []; }
     function liabilities() { return (store.get('liabilities.items')) || []; }
 
+    // Store convention (owned by the Portfolio Tracker): holding.costBasis
+    // is PER-SHARE. Value = (live price || per-share cost) × shares.
+    function holdingValue(h) {
+      var per = num(h.currentPrice) > 0 ? num(h.currentPrice) : num(h.costBasis);
+      return per * num(h.shares);
+    }
     function acctValue(name) {
       return holdings().filter(function (h) { return h.account === name; })
-        .reduce(function (s, h) { return s + num(h.costBasis); }, 0);
+        .reduce(function (s, h) { return s + holdingValue(h); }, 0);
     }
     function acctCount(name) { return holdings().filter(function (h) { return h.account === name; }).length; }
 
@@ -343,10 +350,7 @@ AAPL,50,41900,Schwab 401(k)"></textarea>
     // the scalar `assets` block the current net_worth tool still reads.
     function recompute() {
       var hs = holdings();
-      var total = hs.reduce(function (s, h) {
-        var v = (num(h.currentPrice) > 0) ? num(h.currentPrice) * num(h.shares) : num(h.costBasis);
-        return s + v;
-      }, 0);
+      var total = hs.reduce(function (s, h) { return s + holdingValue(h); }, 0);
       store.set('portfolio.totalValue', total || null, EDIT);
       var oa = otherAssets();
       var byCat = { realEstate: 0, vehicles: 0, other: 0 };
@@ -443,7 +447,7 @@ AAPL,50,41900,Schwab 401(k)"></textarea>
       }).join('') : '<div class="dh-empty">No liabilities yet.</div>';
 
       var assetTotal = otherAssets().reduce(function (s, a) { return s + num(a.value); }, 0)
-        + holdings().reduce(function (s, h) { return s + (num(h.currentPrice) > 0 ? num(h.currentPrice) * num(h.shares) : num(h.costBasis)); }, 0);
+        + holdings().reduce(function (s, h) { return s + holdingValue(h); }, 0);
       var liabTotal = rows.reduce(function (s, l) { return s + num(l.balance); }, 0);
       $('dh-net-val').textContent = fmtFull(assetTotal - liabTotal);
     }
@@ -515,6 +519,10 @@ AAPL,50,41900,Schwab 401(k)"></textarea>
       var ac = findCol(headers, ['account']);
       // Fallback for 3-col generic (ticker,shares,cost_basis) with odd headers
       if (tk < 0 && headers.length >= 3) { tk = 0; sh = 1; cb = 2; }
+      // Store convention (Portfolio Tracker): costBasis is PER-SHARE.
+      // Vanguard-style "... total" headers carry lot totals → divide by
+      // shares; "average"/generic cost headers are already per-share.
+      var costIsTotal = cb >= 0 && headers[cb] != null && /total/i.test(headers[cb]);
       var existing = holdings();
       var acctNames = accounts().map(function (a) { return a.name; });
       return lines.slice(1).map(function (line) {
@@ -525,7 +533,10 @@ AAPL,50,41900,Schwab 401(k)"></textarea>
         var already = existing.some(function (h) { return h.ticker === ticker && (!account || h.account === account); });
         var status = already ? 'update' : 'new';
         if (account && acctNames.length && acctNames.indexOf(account) < 0) status = 'warn';
-        return { ticker: ticker, shares: num(c[sh]), costBasis: num(c[cb]), account: account, status: status };
+        var shares = num(c[sh]);
+        var rawCost = num(c[cb]);
+        var costPerShare = (costIsTotal && rawCost && shares) ? rawCost / shares : rawCost;
+        return { ticker: ticker, shares: shares, costBasis: costPerShare, account: account, status: status };
       }).filter(Boolean);
     }
     function renderPreview() {
@@ -540,9 +551,10 @@ AAPL,50,41900,Schwab 401(k)"></textarea>
         '<span class="dh-ok"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="20 6 9 17 4 12"></polyline></svg>Columns mapped automatically</span></div>' +
         '<div class="dh-prow dh-prow--head"><span class="dh-ph">Ticker</span><span class="dh-ph dh-cell--r">Shares</span><span class="dh-ph dh-cell--r">Cost Basis</span><span class="dh-ph" style="padding-left:12px;">Account</span><span class="dh-ph dh-cell--r">Status</span></div>' +
         shown.map(function (r) {
+          var costTotal = (r.costBasis && r.shares) ? r.costBasis * r.shares : r.costBasis;
           return '<div class="dh-prow"><span class="dh-cell--tk">' + esc(r.ticker) + '</span>' +
             '<span class="dh-cell dh-cell--r dh-mono">' + (r.shares ? r.shares.toLocaleString('en-US') : '—') + '</span>' +
-            '<span class="dh-cell dh-cell--r dh-mono">' + (r.costBasis ? fmtFull(r.costBasis) : '—') + '</span>' +
+            '<span class="dh-cell dh-cell--r dh-mono">' + (costTotal ? fmtFull(costTotal) : '—') + '</span>' +
             '<span class="dh-cell" style="padding-left:12px;">' + (esc(r.account) || '—') + '</span>' +
             '<span class="dh-cell--r ' + stClass[r.status] + '">' + stLabel[r.status] + '</span></div>';
         }).join('') +
@@ -556,7 +568,8 @@ AAPL,50,41900,Schwab 401(k)"></textarea>
       parsed.forEach(function (r) {
         var idx = hs.findIndex(function (h) { return h.ticker === r.ticker && (h.account || '') === (r.account || ''); });
         if (idx >= 0) { hs[idx].shares = r.shares; hs[idx].costBasis = r.costBasis; }
-        else hs.push({ ticker: r.ticker, name: r.ticker, shares: r.shares, costBasis: r.costBasis, account: r.account, assetClass: 'equity', currentPrice: null, priceUpdatedAt: null });
+        // `id` is required by the Portfolio Tracker (row edit/delete key on it)
+        else hs.push({ id: r.ticker + '-' + Date.now() + '-' + Math.random().toString(36).slice(2, 6), ticker: r.ticker, name: r.ticker, shares: r.shares, costBasis: r.costBasis, account: r.account, assetClass: 'equity', currentPrice: null, priceUpdatedAt: null });
       });
       store.set('portfolio.holdings', hs, EDIT);
       // record import + auto-register any unknown accounts referenced
@@ -640,7 +653,7 @@ AAPL,50,41900,Schwab 401(k)"></textarea>
     });
     bindForm('dh-liab-add', 'dh-liab-form', function (fd) {
       var items = liabilities();
-      items.push({ id: uid(), name: fd.get('name').trim(), rate: num(fd.get('rate')) || null, balance: num(fd.get('balance')), remainingTerm: null });
+      items.push({ id: uid(), name: fd.get('name').trim(), type: fd.get('type') || 'other', rate: num(fd.get('rate')) || null, balance: num(fd.get('balance')), remainingTerm: null });
       store.set('liabilities.items', items, EDIT);
       store.set('liabilities.total', items.reduce(function (s, l) { return s + num(l.balance); }, 0), EDIT);
       renderAll(); flash('Liability added.');

--- a/index.html
+++ b/index.html
@@ -965,8 +965,9 @@
         if (!store) return;
         var s = store.export();
         var holdings = (s.portfolio && s.portfolio.holdings) || [];
+        // holding.costBasis is PER-SHARE (Portfolio Tracker convention)
         var portfolioVal = Number(s.portfolio && s.portfolio.totalValue) ||
-          holdings.reduce(function (t, h) { return t + (Number(h.currentPrice) > 0 ? Number(h.currentPrice) * Number(h.shares) : (Number(h.costBasis) || 0)); }, 0);
+          holdings.reduce(function (t, h) { var per = Number(h.currentPrice) > 0 ? Number(h.currentPrice) : (Number(h.costBasis) || 0); return t + per * (Number(h.shares) || 0); }, 0);
         var otherAssets = ((s.otherAssets) || []).reduce(function (t, a) { return t + (Number(a.value) || 0); }, 0);
         var retire = Number(s.retirement && s.retirement.balances && s.retirement.balances.total) || 0;
         var liabItems = (s.liabilities && s.liabilities.items) || [];


### PR DESCRIPTION
Continues **step 4** (tools read from the Data Hub). Investigation showed the Tracker and Net Worth already *read* the hub's store paths — but the hub was writing data that violated the store's contract. This fixes the contract and proves the flow end-to-end.

## The bug
`holding.costBasis` is **per-share** — the convention set by the Portfolio Tracker (its CSV import divides Vanguard "…Total" columns by shares; all its valuations/row-edits assume per-share). The Data Hub was committing **lot totals** into the same field → a hub-imported holding would be over-valued ~shares× in the tracker (e.g. VTI 120sh @ "$198,400/share" ≈ $23.8M).

## Fixes (`data_hub.html`)
- `parseCSV()` mirrors the tracker rule (`/total/i` header → divide by shares) and commits **per-share** `costBasis`; preview still displays lot totals (mockup style); paste placeholder/hint now per-share.
- New holdings get an **`id`** — the tracker keys row edit/delete/quote-merge on `h.id`; id-less rows would mis-target edits.
- `holdingValue()` (= `(currentPrice||costBasis)×shares`) used by account values / recompute / net-of-liabilities.
- Liability form gains a **type** select matching Net Worth's options (rows previously rendered "undefined" type there).

`index.html`: same per-share fix in the dashboard KPI fallback.

## Verified end-to-end (headless Chrome)
- Hub paste (generic per-share + Vanguard-style total) → store `cb=165.34` / `cb=50` with ids → **Portfolio Tracker mounts both rows** with correct Cost/Share + Total Cost, re-syncs `totalValue=24840.8` — no unit explosion.
- Hub-entered Home $680K + Mortgage $312K (2.75%) → **Net Worth** shows assets $680K / liabilities $312K / **net worth $368K**, matching the hub's "Net of liabilities".

## Notes
Tracker keeps its own CSV import for now and doesn't live-subscribe while open (iframe remounts per navigation, so hub changes appear on next visit). Remaining step-4: charts + retirement readiness from real data; scenario/preferences consumption in tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)