### PR TITLE
Reskin the 5 Tailwind tools' internals to the theme tokens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -446,6 +446,31 @@ Phase 13j (step 4 slice 5 — live Performance table):
   remaining: scenario/fedBracket/currencyFormat consumption in tools;
   Data Hub polish.
 
+Phase 13k (Tailwind tool reskin):
+- `assets/tw-reskin.css?v=1` (NEW — linked after theme.css on the 5
+  React/Tailwind tools: portfolio_tracker, expenses, TaxEstimatorV5,
+  roth_conversion, TaxAssetCalcv4). Re-points their hardcoded Tailwind
+  color utilities at the shared theme tokens WITHOUT touching any
+  tool's markup: blue/indigo/purple/violet → `--primary` family
+  (solid 600s also force `color: var(--on-primary)`), emerald/green →
+  `--pos`, red → `--neg`, amber/orange → `--warn`; hover/active/
+  disabled/focus-ring variants covered; native radio/checkbox/range
+  get `accent-color: var(--primary)`. Neutral gray/slate untouched.
+- **`!important` is load-bearing**: the Tailwind Play CDN injects its
+  stylesheet at runtime (after any static `<link>`), so specificity
+  alone can't win. The selector list is the exact class inventory of
+  the 5 tools — extend it if a tool gains new color utilities.
+- Because everything maps to tokens, the internals follow the accent
+  picker AND the dark palette automatically (verified: accent=blue +
+  dark renders tracker buttons in the dark-blue accent token).
+- Verified renders: tracker, expenses, TaxEstimatorV5, roth all green
+  in light mode. TaxAssetCalcv4 blanks in HEADLESS Chrome both before
+  and after the change (heavy Babel+D3 page vs virtual-time budget) —
+  pre-existing headless limitation, not a regression; the reskin is
+  pure CSS.
+- Charts inside tools (Chart.js/D3 JS-set colors) keep their own
+  palettes — only class-styled UI was reskinned.
+
 ## Constraints to preserve
 
 - **Zero build step.** No Vite/Webpack until scope demands it.

--- a/TaxAssetCalcv4.html
+++ b/TaxAssetCalcv4.html
@@ -34,6 +34,7 @@
     <!-- Wealth Suite shared shell -->
     <link rel="stylesheet" href="assets/suite.css?v=6">
     <link rel="stylesheet" href="assets/theme.css?v=1">
+    <link rel="stylesheet" href="assets/tw-reskin.css?v=1">
     <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
     <script src="assets/suite-state.js?v=8" defer></script>
     <script src="assets/suite.js?v=13" defer></script>

--- a/TaxEstimatorV5.html
+++ b/TaxEstimatorV5.html
@@ -19,6 +19,7 @@
   <!-- Wealth Suite shared shell -->
   <link rel="stylesheet" href="assets/suite.css?v=6">
   <link rel="stylesheet" href="assets/theme.css?v=1">
+  <link rel="stylesheet" href="assets/tw-reskin.css?v=1">
   <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
   <script src="assets/suite-state.js?v=8" defer></script>
   <script src="assets/suite.js?v=13" defer></script>

--- a/assets/tw-reskin.css
+++ b/assets/tw-reskin.css
@@ -1,0 +1,98 @@
+/* =============================================================
+ * Wealth Suite — Tailwind reskin (design-handoff palette)
+ * -------------------------------------------------------------
+ * The 5 React tools (portfolio_tracker, expenses, TaxEstimatorV5,
+ * roth_conversion, TaxAssetCalcv4) style their internals with
+ * Tailwind utility classes hardcoding blue/indigo brand hues. This
+ * layer re-points those utilities at the shared theme tokens so the
+ * tools match the handoff look WITHOUT touching any tool's markup —
+ * and follow the accent picker + dark palette automatically (tokens
+ * are re-declared per theme/accent).
+ *
+ * !important is load-bearing: the Tailwind Play CDN injects its
+ * stylesheet at runtime (after any static <link>), so specificity
+ * alone can't win. The class list below is the exact inventory used
+ * by the 5 tools (see CLAUDE.md Phase 13k); extend it if a tool
+ * gains new color utilities.
+ *
+ * Mapping:  blue/indigo/purple/violet → --primary family
+ *           emerald/green             → --pos
+ *           red                       → --neg
+ *           amber/orange              → --warn
+ * Neutral gray/slate utilities are left untouched.
+ * ============================================================= */
+
+/* ---- Native controls follow the accent ---- */
+input[type="radio"], input[type="checkbox"], input[type="range"], progress {
+  accent-color: var(--primary);
+}
+
+/* ---- Brand: solid fills (buttons, active tabs) ---- */
+.bg-blue-600, .bg-indigo-600, .bg-purple-600, .bg-violet-600, .bg-emerald-600 {
+  background-color: var(--primary) !important;
+  color: var(--on-primary) !important;
+}
+.hover\:bg-blue-700:hover, .hover\:bg-indigo-700:hover, .hover\:bg-purple-700:hover,
+.hover\:bg-violet-700:hover, .hover\:bg-emerald-700:hover,
+.active\:bg-blue-800:active, .active\:bg-violet-800:active, .active\:bg-emerald-800:active {
+  background-color: var(--primary-strong) !important;
+}
+.disabled\:bg-violet-300:disabled, .disabled\:bg-emerald-300:disabled {
+  background-color: var(--primary-weak) !important;
+  color: var(--primary-text) !important;
+}
+
+/* ---- Brand: weak fills (chips, highlight cards) ---- */
+.bg-blue-50, .bg-blue-100, .bg-indigo-50, .bg-indigo-100, .bg-purple-50 {
+  background-color: var(--primary-weak) !important;
+}
+.hover\:bg-blue-100:hover { background-color: var(--primary-weak) !important; }
+
+/* ---- Brand: text ---- */
+.text-blue-400, .text-blue-500, .text-blue-600, .text-blue-700, .text-blue-800,
+.text-indigo-400, .text-indigo-500, .text-indigo-600, .text-indigo-700, .text-indigo-800,
+.text-purple-700, .text-violet-700 {
+  color: var(--primary-text) !important;
+}
+
+/* ---- Brand: borders + rings (focus states, selected cards) ---- */
+.border-blue-100, .border-blue-200, .border-indigo-100, .border-indigo-200 {
+  border-color: var(--primary-weak) !important;
+}
+.border-blue-500, .border-indigo-500,
+.focus\:border-indigo-500:focus { border-color: var(--primary) !important; }
+.ring-blue-400, .ring-blue-500,
+.focus\:ring-blue-400:focus, .focus\:ring-indigo-500:focus, .focus\:ring-purple-500:focus {
+  --tw-ring-color: var(--primary) !important;
+}
+
+/* ---- Positive (emerald/green) ---- */
+.text-emerald-400, .text-emerald-500, .text-emerald-600, .text-emerald-700, .text-emerald-800,
+.text-green-700, .hover\:text-emerald-800:hover {
+  color: var(--pos) !important;
+}
+.bg-emerald-50, .bg-emerald-100, .hover\:bg-emerald-200:hover {
+  background-color: var(--pos-weak) !important;
+}
+.border-emerald-100, .border-emerald-200 { border-color: var(--pos-weak) !important; }
+.border-emerald-300 { border-color: var(--pos) !important; }
+
+/* ---- Negative (red) ---- */
+.text-red-400, .text-red-500, .text-red-600, .text-red-700,
+.hover\:text-red-400:hover, .hover\:text-red-600:hover {
+  color: var(--neg) !important;
+}
+.bg-red-50, .bg-red-100 { background-color: var(--neg-weak) !important; }
+.border-red-100, .border-red-200 { border-color: var(--neg-weak) !important; }
+.border-red-300, .border-red-400 { border-color: var(--neg) !important; }
+
+/* ---- Warning (amber/orange) ---- */
+.text-amber-500, .text-amber-600, .text-amber-700, .text-amber-800,
+.text-orange-500, .text-orange-600, .text-orange-700 {
+  color: var(--warn) !important;
+}
+.bg-amber-50, .bg-amber-100, .hover\:bg-amber-100:hover {
+  background-color: var(--warn-weak) !important;
+}
+.border-amber-100, .border-amber-200 { border-color: var(--warn-weak) !important; }
+.border-amber-300 { border-color: var(--warn) !important; }

--- a/expenses.html
+++ b/expenses.html
@@ -12,6 +12,7 @@
     <!-- Wealth Suite shared shell -->
     <link rel="stylesheet" href="assets/suite.css?v=6">
     <link rel="stylesheet" href="assets/theme.css?v=1">
+    <link rel="stylesheet" href="assets/tw-reskin.css?v=1">
     <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
     <script src="assets/suite-state.js?v=8" defer></script>
     <script src="assets/suite.js?v=13" defer></script>

--- a/portfolio_tracker.html
+++ b/portfolio_tracker.html
@@ -12,6 +12,7 @@
     <!-- Wealth Suite shared shell -->
     <link rel="stylesheet" href="assets/suite.css?v=6">
     <link rel="stylesheet" href="assets/theme.css?v=1">
+    <link rel="stylesheet" href="assets/tw-reskin.css?v=1">
     <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
     <script src="assets/suite-state.js?v=8" defer></script>
     <script src="assets/suite.js?v=13" defer></script>

--- a/roth_conversion.html
+++ b/roth_conversion.html
@@ -12,6 +12,7 @@
     <!-- Wealth Suite shared shell -->
     <link rel="stylesheet" href="assets/suite.css?v=6">
     <link rel="stylesheet" href="assets/theme.css?v=1">
+    <link rel="stylesheet" href="assets/tw-reskin.css?v=1">
     <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
     <script src="assets/suite-state.js?v=8" defer></script>
     <script src="assets/suite.js?v=13" defer></script>


### PR DESCRIPTION
The deferred "pixel-perfect reskin" of the 5 React/Tailwind tools (portfolio_tracker, expenses, TaxEstimatorV5, roth_conversion, TaxAssetCalcv4) — their internals were still hardcoded Tailwind blue/indigo.

## Approach: CSS override layer, zero markup changes
New **`assets/tw-reskin.css`** (linked after theme.css on the 5 tools) re-points their exact Tailwind color-class inventory at the shared theme tokens:
- **blue / indigo / purple / violet → `--primary` family** (solid 600s also force `color: var(--on-primary)`); hover / active / disabled / focus-ring variants covered
- **emerald/green → `--pos`**, **red → `--neg`**, **amber/orange → `--warn`**
- native radio / checkbox / range get `accent-color: var(--primary)`
- neutral gray/slate untouched

`!important` is load-bearing: the Tailwind Play CDN injects its stylesheet at runtime (after any static `<link>`), so specificity alone can't win.

## Free wins from token mapping
Tool internals now follow the **accent picker** and **dark palette** automatically — verified accent=blue + dark renders the tracker's buttons in the *dark-blue accent token*, not Tailwind's hardcoded blue.

## Verified (headless Chrome)
- Tracker, Expenses, Tax Estimator, Roth all render the handoff green in light mode (active tabs, CTAs, section labels, limit chips).
- TaxAssetCalcv4 blanks in **headless** Chrome both before and after the change (heavy Babel+D3 page vs virtual-time budget) — pre-existing headless limitation, not a regression; the reskin is pure CSS with no behavior surface.
- Chart.js/D3 JS-set colors keep their own palettes (only class-styled UI reskinned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)