### PR TITLE
Fix blank Asset & Cap-Gains (Babel pin) + Estate Plan as its own sidebar route

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -471,6 +471,27 @@ Phase 13k (Tailwind tool reskin):
 - Charts inside tools (Chart.js/D3 JS-set colors) keep their own
   palettes — only class-styled UI was reskinned.
 
+Phase 13l (fixes: Asset Calc Babel pin + Estate Plan sidebar route):
+- **TaxAssetCalcv4.html was blank** (React never mounted): it loaded
+  UNPINNED `@babel/standalone` from unpkg — missed by the earlier
+  suite-wide pin (aa7ee7c) — and unpkg now serves Babel 8, which
+  rejects raw `>` in JSX text (`assets held > 1 year`, inline script
+  629:153). Fixed: pinned to 7.29.7 like every other React page AND
+  escaped the `>` to `&gt;`. Gotcha reinforced: any new React tool must
+  pin @babel/standalone@7.29.7.
+- **Estate Plan is now its own sidebar destination**: the Estate tab
+  button was removed from retirement_master_plan_2.html's tab bar
+  (pane `#est` kept), the tool gained expenses-style hash deep-links
+  (`activateTabFromHash`: `#ov/#proj/#est/…`; `showTab` tolerates a
+  null button; an emptied/unknown hash mid-session resets to Overview —
+  that's what shell-nav Estate → Retirement produces, since only the
+  fragment changes and the iframe doesn't reload).
+- **Shell router supports sub-hash routes**: ROUTES may key
+  `file.html#subtab` (Estate Plan = `retirement_master_plan_2.html#est`);
+  `routeFromHref/resolveRoute` normalize (incl. %23-encoded pasted
+  URLs), setActive does exact route matching so Retirement Plan and
+  Estate Plan highlight independently.
+
 ## Constraints to preserve
 
 - **Zero build step.** No Vite/Webpack until scope demands it.
@@ -501,6 +522,9 @@ Phase 13k (Tailwind tool reskin):
   screenshots, use headless Chrome
   (`google-chrome --headless --screenshot=...`).
 - Asset Calc supports tax years 2024, 2025, 2026 — adapter clamps to latest supported year if store has a newer value.
+- **Pin `@babel/standalone@7.29.7`** on every React page. Unpinned CDN
+  URLs now serve Babel 8, which hard-errors on raw `>`/`<` in JSX text
+  → blank page (React never mounts). Also escape `>` as `&gt;` in JSX.
 
 ## Workflow
 

--- a/TaxAssetCalcv4.html
+++ b/TaxAssetCalcv4.html
@@ -45,7 +45,8 @@
 
     <!-- React and ReactDOM CDN -->
     <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
-    <script crossorigin src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <!-- Pinned: Babel 8 rejects raw `>` in JSX text — see CLAUDE.md gotcha -->
+    <script crossorigin src="https://unpkg.com/@babel/standalone@7.29.7/babel.min.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
 
 
@@ -677,7 +678,7 @@
                         </div>
 
                         <div>
-                            <label htmlFor="longTermGains" className="block text-sm font-medium text-gray-700 mb-1">Long-Term Capital Gains (assets held > 1 year):</label>
+                            <label htmlFor="longTermGains" className="block text-sm font-medium text-gray-700 mb-1">Long-Term Capital Gains (assets held &gt; 1 year):</label>
                             <input
                                 type="text"
                                 id="longTermGains"

--- a/index.html
+++ b/index.html
@@ -302,7 +302,7 @@
         <span class="sb-x">Tax Plan (Estimator)</span>
         <span class="ws-badge ws-badge--q2 sb-x">Q2</span>
       </a>
-      <a class="ws-navitem" href="retirement_master_plan_2.html" title="Estate Plan">
+      <a class="ws-navitem" href="retirement_master_plan_2.html#est" title="Estate Plan">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
         <span class="sb-x">Estate Plan</span>
       </a>
@@ -746,7 +746,9 @@
       'golden_ratio_portfolio_dashboard.html': 'Golden φ Portfolio',
       'monte_carlo.html': 'Monte Carlo',
       'data_hub.html': 'Data Hub',
-      'settings.html': 'Settings'
+      'settings.html': 'Settings',
+      // Sub-hash routes: the tool page + a tab deep-link inside it
+      'retirement_master_plan_2.html#est': 'Estate Plan'
     };
     var frame = document.getElementById('ws-frame');
     var dashView = document.getElementById('ws-dash-view');
@@ -762,10 +764,28 @@
       var clean = href.split('#')[0].split('?')[0].split('/');
       return clean[clean.length - 1];
     }
-    function setActive(file) {
+    // Normalized route from an href: "file.html" or "file.html#subtab"
+    // (sub-hash routes let one tool page host multiple sidebar entries,
+    // e.g. Estate Plan → retirement_master_plan_2.html#est).
+    function routeFromHref(href) {
+      if (!href) return '';
+      var file = fileFromHref(href);
+      var hashIdx = href.indexOf('#');
+      var sub = hashIdx >= 0 ? href.slice(hashIdx) : '';
+      return sub && ROUTES[file + sub] ? file + sub : file;
+    }
+    // Raw shell-hash content → known route ('' = dashboard).
+    // Tolerates %23-encoded sub-hashes in shared/pasted URLs.
+    function resolveRoute(raw) {
+      try { raw = decodeURIComponent(raw); } catch (e) {}
+      if (ROUTES[raw]) return raw;
+      var f = fileFromHref(raw);
+      return ROUTES[f] ? f : '';
+    }
+    function setActive(route) {
       navItems.forEach(function (a) {
-        var on = file ? (fileFromHref(a.getAttribute('href')) === file)
-                      : (fileFromHref(a.getAttribute('href')) === 'index.html');
+        var r = routeFromHref(a.getAttribute('href'));
+        var on = route ? (r === route) : (r === 'index.html');
         a.classList.toggle('is-active', on);
         if (on) a.setAttribute('aria-current', 'page'); else a.removeAttribute('aria-current');
       });
@@ -782,32 +802,28 @@
       document.title = 'Wealth Suite — Dashboard';
       setActive(null);
     }
-    function showTool(file) {
-      var title = ROUTES[file];
+    function showTool(routeKey) {
+      var title = ROUTES[routeKey];
       if (!title) { showDashboard(); return; }
       if (dashView) dashView.hidden = true;
       if (content) content.classList.add('is-tool');
-      if (frame) { if (frame.getAttribute('src') !== file) frame.setAttribute('src', file); frame.hidden = false; frame.setAttribute('title', title); }
+      if (frame) { if (frame.getAttribute('src') !== routeKey) frame.setAttribute('src', routeKey); frame.hidden = false; frame.setAttribute('title', title); }
       if (backEl) backEl.hidden = false;
       if (dateSep) dateSep.hidden = true;
       var d = document.getElementById('ws-date'); if (d) d.hidden = true;
-      if (newtabEl) { newtabEl.hidden = false; newtabEl.setAttribute('href', file); }
+      if (newtabEl) { newtabEl.hidden = false; newtabEl.setAttribute('href', routeKey); }
       if (titleEl) titleEl.textContent = title;
       document.title = 'Wealth Suite — ' + title;
-      setActive(file);
-    }
-    function currentFile() {
-      var h = fileFromHref((location.hash || '').replace(/^#/, ''));
-      return ROUTES[h] ? h : '';
+      setActive(routeKey);
     }
     function route() {
-      var f = currentFile();
-      if (f) showTool(f); else showDashboard();
+      var r = resolveRoute((location.hash || '').replace(/^#/, ''));
+      if (r) showTool(r); else showDashboard();
       if (content) content.scrollTop = 0;
       closeMobNav();
     }
-    function navigate(file) {
-      var target = (file && ROUTES[file]) ? ('#' + file) : '#';
+    function navigate(routeKey) {
+      var target = (routeKey && ROUTES[routeKey]) ? ('#' + routeKey) : '#';
       if (location.hash === target) route(); else location.hash = target;
     }
     window.addEventListener('hashchange', route);
@@ -815,9 +831,9 @@
       if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
       var a = e.target.closest && e.target.closest('a[href]');
       if (!a || a.target === '_blank') return;
-      var file = fileFromHref(a.getAttribute('href'));
-      if (file === 'index.html') { e.preventDefault(); navigate(''); }
-      else if (ROUTES[file]) { e.preventDefault(); navigate(file); }
+      var r = routeFromHref(a.getAttribute('href'));
+      if (r === 'index.html') { e.preventDefault(); navigate(''); }
+      else if (ROUTES[r]) { e.preventDefault(); navigate(r); }
     });
     if (backEl) backEl.addEventListener('click', function () { navigate(''); });
     route();

--- a/retirement_master_plan_2.html
+++ b/retirement_master_plan_2.html
@@ -184,7 +184,8 @@ body{font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-serif;backgro
   <button class="nb" onclick="showTab('proj',this)">Projection</button>
   <button class="nb" onclick="showTab('roth',this)">Roth + SS</button>
   <button class="nb" onclick="showTab('tax',this)">Tax strategy</button>
-  <button class="nb" onclick="showTab('est',this)">Estate plan</button>
+  <!-- Estate plan moved to its own sidebar entry — pane #est stays,
+       reached via the #est hash (see activateTabFromHash) -->
   <button class="nb" onclick="showTab('rmd',this)">RMD calculator</button>
   <button class="nb" onclick="showTab('tl',this)">Timeline</button>
 </div>
@@ -744,11 +745,32 @@ function showTab(id, btn) {
   for (var i = 0; i < panes.length; i++) panes[i].classList.remove('on');
   for (var i = 0; i < btns.length; i++) btns[i].classList.remove('on');
   document.getElementById(id).classList.add('on');
-  btn.classList.add('on');
+  if (btn) btn.classList.add('on');
   if (id === 'proj' && !projBuilt) { buildProjChart('base'); projBuilt = true; }
   if (id === 'roth' && !ssBuilt) { buildSSChart(); ssBuilt = true; }
   if (id === 'rmd' && !rmdBuilt) { updateRMD(); rmdBuilt = true; }
 }
+
+// Hash deep-links (#ov/#proj/#est/…) — same pattern as expenses.html.
+// The Estate pane (#est) has no tab button (it lives under the suite
+// sidebar's own "Estate Plan" entry), so showTab tolerates btn=null.
+function activateTabFromHash(isChange) {
+  var id = (location.hash || '').replace('#', '');
+  var pane = id && document.getElementById(id);
+  if (!pane || !pane.classList.contains('pane')) {
+    // Hash cleared/unknown mid-session (e.g. shell nav Estate → Retirement
+    // Plan only removes the fragment) → back to the default Overview tab.
+    if (isChange) { id = 'ov'; pane = document.getElementById('ov'); if (!pane) return; }
+    else return;
+  }
+  var btns = document.querySelectorAll('.nb'), match = null;
+  for (var i = 0; i < btns.length; i++) {
+    if ((btns[i].getAttribute('onclick') || '').indexOf("'" + id + "'") >= 0) { match = btns[i]; break; }
+  }
+  showTab(id, match);
+}
+window.addEventListener('hashchange', function () { activateTabFromHash(true); });
+activateTabFromHash(false);
 
 // ===== Portfolio projection (married — both spouses SS) =====
 function calcPortfolio(gr, ir) {


### PR DESCRIPTION
Two user-reported fixes.

## 1 · Asset & Cap-Gains rendered blank
**Root cause:** the page loaded **unpinned** `@babel/standalone` from unpkg — it was missed by the earlier suite-wide pin (aa7ee7c) — and unpkg now serves **Babel 8**, which rejects raw `>` in JSX text (`assets held > 1 year` at inline script 629:153). React never mounted → blank page. This predates recent work (broken since unpkg rolled Babel 8).

**Fix:** pinned to `@babel/standalone@7.29.7` like every other React page **and** escaped the `>` to `&gt;`. Added a CLAUDE.md gotcha so new React pages always pin.

## 2 · Estate Plan is now its own sidebar destination
Previously the sidebar's Estate Plan just opened the Retirement Plan overview.
- **retirement_master_plan_2.html**: the Estate tab button is removed from the tool's tab bar ("moved"); the pane stays and the tool gained expenses-style **hash deep-links** (`#ov/#proj/#est/…`). An emptied/unknown hash mid-session resets to Overview — exactly what shell-nav Estate → Retirement produces (fragment-only change, iframe doesn't reload).
- **Shell router**: ROUTES can now key `file.html#subtab`; Estate Plan = `retirement_master_plan_2.html#est`. Route normalization handles %23-encoded pasted URLs; active-state matching is exact-route, so Retirement Plan and Estate Plan highlight independently.

## Verified (headless Chrome)
- Asset Calc renders fully, zero console errors, wearing the green reskin.
- Shell route shows the estate pane with "Estate Plan" title + correct sidebar highlight, and no Estate tab in the tool's own tab bar.
- Estate → Retirement Plan transition lands on Overview with the correct highlight (`title=Retirement Plan | active-nav=Retirement Plan | pane=ov`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)