### PR TITLE
Extract Estate Plan into its own standalone page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -492,6 +492,28 @@ Phase 13l (fixes: Asset Calc Babel pin + Estate Plan sidebar route):
   URLs), setActive does exact route matching so Retirement Plan and
   Estate Plan highlight independently.
 
+Phase 13m (Estate Plan extracted to a standalone page):
+- The 13l sub-hash approach still showed the Retirement banner + tab
+  bar around the estate content — not what the user wanted. The estate
+  pane is now **its own page, `estate_plan.html`** (12th tool): the
+  `#est` pane markup was moved out of retirement_master_plan_2.html
+  verbatim, wrapped with a copy of that tool's `<style>` block, its own
+  green `.hdr` banner (fed exemption / WA exclusion / est. WA tax
+  stats), and the standard suite chrome (suite.css/theme.css +
+  suite-state + suite.js; no adapter — static content).
+- retirement_master_plan_2.html no longer contains the pane (tabs:
+  Overview/3-yr buffer/Projection/Roth+SS/Tax strategy/RMD/Timeline).
+  Its hash-tab deep-link support (13l) remains for the other tabs.
+- Router: `estate_plan.html` is a normal ROUTES entry (the sub-hash
+  route mechanism stays but has no entries). Sidebar Estate Plan →
+  estate_plan.html.
+- `assets/suite.js?v=14` (ALL pages): Estate Plan added to the
+  Retirement cluster so the standalone topnav sub-nav shows
+  Master Plan / Estate Plan / Monte Carlo.
+- The page content is copy-heavy static analysis (OBBBA, WA SB 6347,
+  millionaire tax, trust strategy, beneficiary audit) — candidates for
+  store-driven figures later (estate size from net worth, etc.).
+
 ## Constraints to preserve
 
 - **Zero build step.** No Vite/Webpack until scope demands it.

--- a/TaxAssetCalcv4.html
+++ b/TaxAssetCalcv4.html
@@ -37,7 +37,7 @@
     <link rel="stylesheet" href="assets/tw-reskin.css?v=1">
     <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
     <script src="assets/suite-state.js?v=8" defer></script>
-    <script src="assets/suite.js?v=13" defer></script>
+    <script src="assets/suite.js?v=14" defer></script>
     <script src="assets/adapters/asset.js?v=5" defer></script>
 </head>
 <body class="bg-gray-100 flex items-center justify-center min-h-screen py-8">

--- a/TaxEstimatorV5.html
+++ b/TaxEstimatorV5.html
@@ -22,7 +22,7 @@
   <link rel="stylesheet" href="assets/tw-reskin.css?v=1">
   <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
   <script src="assets/suite-state.js?v=8" defer></script>
-  <script src="assets/suite.js?v=13" defer></script>
+  <script src="assets/suite.js?v=14" defer></script>
   <script src="assets/adapters/tax.js?v=5" defer></script>
 </head>
 <body class="bg-slate-50">

--- a/assets/suite.js
+++ b/assets/suite.js
@@ -52,6 +52,7 @@
       label: 'Retirement',
       tools: [
         { href: 'retirement_master_plan_2.html', label: 'Master Plan',  match: ['retirement_master_plan'] },
+        { href: 'estate_plan.html',              label: 'Estate Plan',  match: ['estate_plan'] },
         { href: 'monte_carlo.html',              label: 'Monte Carlo',  match: ['monte_carlo'] },
       ],
     },

--- a/data_hub.html
+++ b/data_hub.html
@@ -303,7 +303,7 @@ AAPL,50,142.80,Schwab 401(k)"></textarea>
 
 </div>
 
-<script src="assets/suite.js?v=13" defer></script>
+<script src="assets/suite.js?v=14" defer></script>
 <script src="assets/suite-state.js?v=8" defer></script>
 <script>
 (function () {

--- a/estate_plan.html
+++ b/estate_plan.html
@@ -1,0 +1,308 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Estate Plan — Wealth Suite</title>
+<meta name="description" content="Estate planning for a WA household — federal OBBBA exemption, WA estate tax, trust strategy, beneficiary audit.">
+<style>
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+/* Phase 8: vars consume suite MD3 tokens when suite.css is loaded;
+   the second var() argument keeps the tool working standalone.
+   --purple has no MD3/status equivalent — maps to tertiary. */
+:root{
+  --bg:var(--md-sys-color-background,#F0F2F5);
+  --surface:var(--md-sys-color-surface-container-lowest,#FFFFFF);
+  --surface2:var(--md-sys-color-surface-container-low,#F7F9FB);
+  --border:var(--md-sys-color-outline-variant,#E2E6EA);
+  --border2:var(--md-sys-color-outline-variant,#CBD5E1);
+  --text:var(--md-sys-color-on-surface,#0F172A);
+  --muted:var(--md-sys-color-on-surface-variant,#64748B);
+  --hint:var(--md-sys-color-outline,#94A3B8);
+  --navy:var(--md-sys-color-primary,#1E3A5F);
+  --blue:var(--status-info,#2563EB);
+  --green:var(--status-positive,#059669);
+  --amber:var(--status-warning,#D97706);
+  --red:var(--status-critical,#DC2626);
+  --purple:#7C3AED;
+  --green-bg:var(--status-positive-container,#ECFDF5);--green-t:var(--status-positive-on,#065F46);
+  --amber-bg:var(--status-warning-container,#FFFBEB);--amber-t:var(--status-warning-on,#92400E);
+  --red-bg:var(--status-critical-container,#FEF2F2);--red-t:var(--status-critical-on,#991B1B);
+  --blue-bg:var(--status-info-container,#EFF6FF);--blue-t:var(--status-info-on,#1E40AF);
+  --purple-bg:#F3F0FF;--purple-t:#4C1D95;
+}
+/* Standalone dark fallbacks — when suite.css is loaded the tokens
+   flip automatically and these resolve to the same values. */
+[data-theme="dark"]{
+  --bg:var(--md-sys-color-background,#121318);
+  --surface:var(--md-sys-color-surface-container,#1E1F25);
+  --surface2:var(--md-sys-color-surface-container-high,#26272D);
+  --border:var(--md-sys-color-outline-variant,#34353B);
+  --border2:var(--md-sys-color-outline-variant,#45464F);
+  --text:var(--md-sys-color-on-surface,#E3E2E9);
+  --muted:var(--md-sys-color-on-surface-variant,#C5C6D0);
+  --hint:var(--md-sys-color-outline,#8F909A);
+  --navy:var(--md-sys-color-primary,#AFC6FF);
+  --blue:var(--status-info,#7BA8FF);
+  --green:var(--status-positive,#34D399);
+  --amber:var(--status-warning,#FBBF24);
+  --red:var(--status-critical,#F87171);
+  --purple:#C4B5FD;
+  --green-bg:var(--status-positive-container,rgba(52,211,153,0.15));--green-t:var(--status-positive-on,#6EE7B7);
+  --amber-bg:var(--status-warning-container,rgba(251,191,36,0.15));--amber-t:var(--status-warning-on,#FCD34D);
+  --red-bg:var(--status-critical-container,rgba(248,113,113,0.15));--red-t:var(--status-critical-on,#FCA5A5);
+  --blue-bg:var(--status-info-container,rgba(123,168,255,0.15));--blue-t:var(--status-info-on,#93C5FD);
+  --purple-bg:rgba(196,181,253,0.15);--purple-t:#DDD6FE;
+}
+html[data-theme="dark"] body{color-scheme:dark}
+[data-theme="dark"] .hdr{background:#0F1421}
+[data-theme="dark"] .sc-btn.on,[data-theme="dark"] .nb.on{color:#0F1421}
+body{font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-serif;background:var(--bg);color:var(--text);font-size:14px;line-height:1.6;min-height:100vh}
+.hdr{background:var(--navy);color:white;padding:18px 28px;display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:12px}
+.hdr-l h1{font-size:17px;font-weight:600}
+.hdr-l p{font-size:11px;opacity:.6;margin-top:2px}
+.hdr-r{display:flex;gap:24px}
+.hs{text-align:right}.hs-v{font-size:19px;font-weight:600}.hs-l{font-size:11px;opacity:.55}
+.nav{background:var(--surface);border-bottom:1px solid var(--border);padding:0 24px;display:flex;overflow-x:auto}
+.nb{padding:13px 15px;border:none;background:transparent;color:var(--muted);cursor:pointer;font-size:13px;font-weight:500;border-bottom:2px solid transparent;white-space:nowrap;font-family:inherit;transition:color .15s}
+.nb:hover{color:var(--text)}.nb.on{color:var(--navy);border-bottom-color:var(--navy)}
+.main{padding:22px 28px;max-width:940px;margin:0 auto}
+.pane{display:none}.pane.on{display:block}
+.g4{display:grid;grid-template-columns:repeat(auto-fit,minmax(155px,1fr));gap:10px;margin-bottom:14px}
+.sc{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:13px 15px}
+.sc-l{font-size:11px;color:var(--muted);margin-bottom:3px;text-transform:uppercase;letter-spacing:.04em}
+.sc-v{font-size:20px;font-weight:600}
+.g{color:var(--green)}.r{color:var(--red)}.b{color:var(--blue)}.a{color:var(--amber)}
+.card{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:17px 19px;margin-bottom:14px}
+.ct{font-size:14px;font-weight:600;margin-bottom:3px}
+.cs{font-size:12px;color:var(--muted);margin-bottom:12px}
+.bdg{display:inline-block;font-size:11px;font-weight:500;padding:2px 8px;border-radius:20px;flex-shrink:0}
+.bdg-r{background:var(--red-bg);color:var(--red-t)}
+.bdg-a{background:var(--amber-bg);color:var(--amber-t)}
+.bdg-b{background:var(--blue-bg);color:var(--blue-t)}
+.bdg-g{background:var(--green-bg);color:var(--green-t)}
+.bdg-p{background:var(--purple-bg);color:var(--purple-t)}
+.ri{display:flex;align-items:flex-start;gap:11px;padding:9px 0;border-bottom:1px solid var(--border)}
+.ri:last-child{border-bottom:none}
+.ri-t{flex:1;font-size:13px;color:var(--muted);line-height:1.6}
+.pb-w{margin-bottom:11px}
+.pb-h{display:flex;justify-content:space-between;font-size:13px;margin-bottom:4px}
+.pb{height:6px;background:var(--border);border-radius:3px;overflow:hidden}
+.pb-f{height:100%;border-radius:3px}
+.tier{border:1px solid var(--border);border-left:3px solid;border-radius:10px;border-top-left-radius:0;border-bottom-left-radius:0;padding:13px 15px;margin-bottom:10px}
+.tier-hd{display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:7px}
+.tier-t{font-size:13px;font-weight:600}.tier-st{font-size:11px;color:var(--muted);margin-top:1px}
+.tier-amt{text-align:right;flex-shrink:0;margin-left:10px}
+.tier-v{font-size:15px;font-weight:600}.tier-y{font-size:11px}
+.tier-b{font-size:12px;color:var(--muted);line-height:1.7}
+.ib{border-radius:8px;padding:10px 13px;font-size:12px;line-height:1.7;margin-top:10px}
+.ib-g{background:var(--green-bg);color:var(--green-t)}
+.ib-a{background:var(--amber-bg);color:var(--amber-t)}
+.ib-r{background:var(--red-bg);color:var(--red-t)}
+.ib-b{background:var(--blue-bg);color:var(--blue-t)}
+.ib-p{background:var(--purple-bg);color:var(--purple-t)}
+.sbg{background:var(--surface2);border-radius:10px;padding:13px 15px;margin-top:12px}
+.sbg-t{font-size:13px;font-weight:600;margin-bottom:9px}
+.cw{position:relative;width:100%;height:300px;margin:10px 0}
+.cw-sm{height:240px}
+.sc-btns{display:flex;gap:6px;flex-wrap:wrap;margin-bottom:11px}
+.sc-btn{padding:5px 11px;border:1px solid var(--border);background:var(--surface);color:var(--muted);cursor:pointer;font-size:12px;font-weight:500;border-radius:6px;transition:all .15s;font-family:inherit}
+.sc-btn:hover{border-color:var(--navy);color:var(--navy)}
+.sc-btn.on{background:var(--navy);color:white;border-color:var(--navy)}
+.cl{display:flex;flex-wrap:wrap;gap:14px;font-size:12px;color:var(--muted);margin-top:8px}
+.cl-i{display:flex;align-items:center;gap:5px}
+.cl-d{width:12px;height:3px;border-radius:2px;display:inline-block}
+.phase{border-left:3px solid;padding:12px 14px;border-radius:0 8px 8px 0;margin-bottom:10px;background:var(--surface2)}
+.phase-hd{display:flex;justify-content:space-between;align-items:center;margin-bottom:6px;flex-wrap:wrap;gap:6px}
+.phase-t{font-size:13px;font-weight:600}
+.phase-b{font-size:12px;color:var(--muted);line-height:1.7}
+.it{display:grid;grid-template-columns:1fr 1fr;gap:3px 20px;font-size:12px;line-height:2}
+.it-k{color:var(--blue-t)}.it-v{font-weight:600;text-align:right;color:var(--blue-t)}
+.kv{display:grid;grid-template-columns:1fr auto;gap:3px 20px;font-size:13px;line-height:2.1}
+.kv-k{color:var(--muted)}.kv-v{font-weight:600;text-align:right}
+.kv-sep{border-top:1px solid var(--border);padding-top:4px;color:var(--text)}
+.kv-sep-g{border-top:1px solid var(--border);padding-top:4px;color:var(--green);font-weight:600;text-align:right}
+.mort-g{display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-bottom:12px}
+.mort-c{background:var(--surface2);border-radius:8px;padding:12px}
+.mort-ct{font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:.04em;font-weight:600;margin-bottom:6px}
+.mort-cb{font-size:12px;color:var(--muted);line-height:1.6}
+.tlh{padding:10px 0 10px 13px;border-left:3px solid var(--border2);margin-bottom:9px}
+.tlh-t{font-size:13px;font-weight:600;margin-bottom:3px}
+.tlh-b{font-size:12px;color:var(--muted);line-height:1.7}
+.benef-g{display:grid;grid-template-columns:1fr 1fr;gap:10px}
+.benef-c{background:var(--surface2);border-radius:8px;padding:12px}
+.benef-ct{font-size:12px;font-weight:600;margin-bottom:4px}
+.benef-cb{font-size:11px;color:var(--muted);line-height:1.6}
+.tl-item{display:flex;gap:14px;padding-bottom:24px}
+.tl-col{display:flex;flex-direction:column;align-items:center}
+.tl-dot{width:34px;height:34px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:600;flex-shrink:0}
+.tl-line{width:1px;flex:1;background:var(--border);margin-top:5px}
+.tl-t{font-size:13px;font-weight:600;margin-bottom:5px;padding-top:5px}
+.tl-b{font-size:12px;color:var(--muted);line-height:1.8}
+.cmp-tbl{width:100%;border-collapse:collapse;font-size:12px;margin-top:10px}
+.cmp-tbl th{text-align:left;padding:8px 10px;background:var(--surface2);font-weight:600;font-size:11px;text-transform:uppercase;letter-spacing:.04em;color:var(--muted);border-bottom:1px solid var(--border)}
+.cmp-tbl td{padding:8px 10px;border-bottom:1px solid var(--border);color:var(--muted);vertical-align:top;line-height:1.5}
+.cmp-tbl tr:last-child td{border-bottom:none}
+.cmp-tbl td:first-child{font-weight:600;color:var(--text);white-space:nowrap}
+.seg{position:absolute;bottom:0;height:48%;transition:width .3s,left .3s}
+.bzone{position:absolute;top:0;height:100%}
+.blbl{position:absolute;top:5px;font-size:10px;font-weight:500;padding:0 5px}
+.rmd-krow{display:flex;justify-content:space-between;padding:7px 0;border-bottom:0.5px solid var(--border);font-size:13px}
+.rmd-krow:last-child{border-bottom:none}
+@media(max-width:600px){
+  .hdr-r{gap:14px}.hs-v{font-size:15px}
+  .g4{grid-template-columns:1fr 1fr}
+  .mort-g,.benef-g,.it{grid-template-columns:1fr}
+  .main{padding:16px}
+  .cmp-tbl{font-size:11px}
+}
+</style>
+</style>
+
+<!-- Wealth Suite shared shell -->
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6"><link rel="stylesheet" href="assets/theme.css?v=1">
+<script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
+<script src="assets/suite-state.js?v=8" defer></script>
+<script src="assets/suite.js?v=14" defer></script>
+</head>
+<body>
+
+<div class="hdr">
+  <div class="hdr-l">
+    <h1>Estate Plan</h1>
+    <p>WA household &middot; community property &middot; extracted from the Retirement Master Plan</p>
+  </div>
+  <div class="hdr-r">
+    <div class="hs"><div class="hs-v">$30M</div><div class="hs-l">Fed exemption (MFJ)</div></div>
+    <div class="hs"><div class="hs-v" style="color:#FCD34D">$3M</div><div class="hs-l">WA exclusion</div></div>
+    <div class="hs"><div class="hs-v" style="color:#FCA5A5">~$50k</div><div class="hs-l">Est. WA tax</div></div>
+  </div>
+</div>
+
+<div id="est" class="pane on">
+  <div class="card" style="border-color:var(--blue)">
+    <div class="ct" style="color:var(--blue)">OBBBA (signed July 4, 2025) — federal estate tax permanently resolved</div>
+    <div class="cs">The One Big Beautiful Bill Act permanently raised the federal estate/gift/GST exemption. No more sunset anxiety.</div>
+    <div class="g4">
+      <div class="sc"><div class="sc-l">Federal exemption (2026+)</div><div class="sc-v g">$15M</div></div>
+      <div class="sc"><div class="sc-l">MFJ combined (portability)</div><div class="sc-v g">$30M</div></div>
+      <div class="sc"><div class="sc-l">Your est. estate</div><div class="sc-v">$3.5M+</div></div>
+      <div class="sc"><div class="sc-l">Federal estate tax due</div><div class="sc-v g">$0</div></div>
+    </div>
+    <div class="ib ib-g">At $3.5M, you are well below the $30M MFJ federal exemption. Federal estate tax is permanently a non-issue for your estate. However, the exemption is indexed to inflation from 2027 — file portability election on first spouse's death (IRS Form 706) to preserve the deceased spouse's unused exclusion. This is free insurance even when clearly under the limit.</div>
+  </div>
+
+  <div class="card" style="border-color:var(--red)">
+    <div class="ct" style="color:var(--red)">WA state estate tax — SB 6347 (updated rates, effective July 2026)</div>
+    <div class="cs">WA estate tax is separate from federal. New SB 6347 restores pre-2025 rates (top rate: 20%, down from 35%). $3M exclusion retained, NOT indexed for inflation.</div>
+    <div class="g4">
+      <div class="sc"><div class="sc-l">WA exclusion</div><div class="sc-v">$3.0M</div></div>
+      <div class="sc"><div class="sc-l">Your estate</div><div class="sc-v a">$3.5M+</div></div>
+      <div class="sc"><div class="sc-l">WA taxable excess</div><div class="sc-v a">~$0.5M</div></div>
+      <div class="sc"><div class="sc-l">Est. WA estate tax</div><div class="sc-v a">~$50k</div></div>
+    </div>
+    <div class="ib ib-r">WA estate tax rates run 10–20% on the excess above $3M. The $3M exclusion does NOT adjust for inflation and WA does NOT allow portability between spouses — each spouse needs their own $3M exclusion via proper trust planning (A/B trust). Without an A/B trust, only one $3M exclusion is available. With proper planning: $6M combined exclusion means you pay little to no WA estate tax at $3.5M. But as your estate grows past $6M, this protection erodes.</div>
+  </div>
+
+  <div class="card" style="border-color:var(--red)">
+    <div class="ct" style="color:var(--red)">WA millionaire tax — SB 6346 (effective Jan 1, 2028)</div>
+    <div class="cs">9.9% tax on WA household income exceeding $1M/year. Applies to residents, part-year residents, and nonresidents with WA-source income. First returns due April 2029.</div>
+    <div class="ri"><span class="bdg bdg-r">Critical</span><span class="ri-t"><strong style="color:var(--text)">$1M threshold per household, NOT per person.</strong> Unlike federal MFJ, the $1M is not doubled for married couples. Large Roth conversions, capital gains from buffer replenishment, or RMDs could push you over $1M in any given year. At $250k spend + $150k Roth conversion + $100k cap gains = $500k — safe. But large one-time events (property sale, stock windfall) could trigger it.</span></div>
+    <div class="ri"><span class="bdg bdg-a">Planning</span><span class="ri-t"><strong style="color:var(--text)">Roth conversion pacing matters.</strong> Converting $350k/yr is safe if total household income stays under $1M. But if combined with dividends, capital gains, and other income, you could inadvertently cross the $1M line. Model total AGI before each year's conversion.</span></div>
+    <div class="ri"><span class="bdg bdg-b">Credits</span><span class="ri-t"><strong style="color:var(--text)">Offsetting credits available:</strong> WA capital gains tax credit (avoids double-tax on same income), B&O tax credit, other state income tax credit (OSTC) if you have income taxed in another state. Charitable deduction up to $100k against WA taxable income. Pass-through entity tax (PTET) election available for business owners.</span></div>
+    <div class="ri"><span class="bdg bdg-r">Legal risk</span><span class="ri-t"><strong style="color:var(--text)">Constitutionality uncertain.</strong> Legal challenges are underway — WA Supreme Court has granted accelerated review in Heywood v. Hobbs. The tax may be struck down or modified. However, plan as if it will survive — don't rely on litigation outcomes for financial planning.</span></div>
+    <div class="ib ib-a">The combination of WA's 9.9% millionaire tax, 7% capital gains tax, and 10–20% estate tax makes WA one of the most aggressive state tax environments for high-net-worth retirees. NV residency eliminates all three. See the WA vs NV comparison table below.</div>
+  </div>
+
+  <div class="card">
+    <div class="ct">WA vs NV — state residency strategy matrix (today's $ at retirement)</div>
+    <div class="cs">20-year cumulative tax impact comparison. NV has zero income tax, zero capital gains tax, zero estate tax.</div>
+    <table class="cmp-tbl">
+      <thead>
+        <tr>
+          <th>Wealth tier</th>
+          <th>WA strategy</th>
+          <th>NV strategy</th>
+          <th>20-yr delta (vs NV)</th>
+          <th>Recommendation</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>&lt;$5M</td>
+          <td>A/B trust; protect WA $3M exclusion per spouse</td>
+          <td>Not needed</td>
+          <td style="font-weight:600;color:var(--green)">$0–$300k</td>
+          <td>Keep it simple — focus on WA estate planning, not relocation</td>
+        </tr>
+        <tr>
+          <td>$5M–$10M</td>
+          <td>A/B trust + optimize taxes; annual gifting</td>
+          <td>Selective trust</td>
+          <td style="font-weight:600;color:var(--amber)">$300k–$1.2M</td>
+          <td>Consider NV only if large liquidity event is coming or millionaire tax applies</td>
+        </tr>
+        <tr style="background:var(--blue-bg)">
+          <td style="color:var(--blue-t)">$3.5M ← you</td>
+          <td style="color:var(--blue-t)">A/B trust + Roth conversions + DAF; WA estate tax ~$50k with proper trust; millionaire tax ~$0 if income managed below $1M</td>
+          <td style="color:var(--blue-t)">NV trust optional; mainly benefit if large liquidity events or estate growth expected</td>
+          <td style="font-weight:600;color:var(--blue-t)">$0–$300k</td>
+          <td style="color:var(--blue-t)"><strong>Focus on WA A/B trust — NV residency not needed at this estate size unless large capital events are planned</strong></td>
+        </tr>
+        <tr>
+          <td>$10M–$20M</td>
+          <td>A/B + optimize; income + estate tax drag meaningful</td>
+          <td>Trust + consider move</td>
+          <td style="font-weight:600;color:var(--red)">$1.2M–$4M</td>
+          <td>Start NV trust now; plan relocation before major gains events</td>
+        </tr>
+        <tr>
+          <td>$20M–$40M</td>
+          <td>Income + estate tax drag very high</td>
+          <td>Trust + move</td>
+          <td style="font-weight:600;color:var(--red)">$4M–$10M</td>
+          <td>Execute NV trust immediately and plan a clean residency move</td>
+        </tr>
+        <tr>
+          <td>$40M+</td>
+          <td>Very high compounding leakage across all WA taxes</td>
+          <td>Core NV strategy</td>
+          <td style="font-weight:600;color:var(--red)">$10M–$50M+</td>
+          <td>Make NV your base — full trust + residency strategy is essential</td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="ib ib-b" style="margin-top:14px"><strong>NV residency requirements for WA residents:</strong> (1) Establish genuine physical presence — spend 183+ days/yr in NV; (2) Get NV driver's license, voter registration, vehicle registration; (3) Change bank accounts, doctors, mail; (4) Sever WA domicile indicators — WA will audit aggressively, especially after SB 6346; (5) Consider purchasing or leasing NV property (Reno/Las Vegas/Henderson); (6) Timing: complete the move before Jan 1, 2028 to avoid the first year of WA millionaire tax. Note: WA SB 6346 also taxes nonresidents on WA-source income — if you retain WA rental property, business interests, or employment compensation, those remain taxable.</div>
+  </div>
+
+  <div class="card">
+    <div class="ct">What is estate and beneficiary coordination?</div>
+    <div style="font-size:13px;color:var(--muted);line-height:1.8;margin-bottom:12px">It means aligning three things: (1) how assets are <strong style="color:var(--text)">titled</strong> (community property vs. separate in WA), (2) <strong style="color:var(--text)">beneficiary designations</strong> on accounts (these override your will entirely), and (3) <strong style="color:var(--text)">estate documents</strong> (A/B trust, wills, POAs, healthcare directives for both spouses). A mismatch between any of these can send assets to the wrong person, trigger large taxes, or tie assets up in probate for years.</div>
+    <div style="font-size:13px;color:var(--muted);line-height:1.8"><strong style="color:var(--text)">SECURE Act 2.0 impact:</strong> Non-spouse beneficiaries who inherit a traditional IRA must withdraw everything within 10 years and pay ordinary income tax. A $2M traditional IRA to children = $400–600k+ in taxes. A $2M <em>Roth</em> IRA to children = zero tax, same 10-year window. This single difference justifies the entire Roth conversion strategy.</div>
+  </div>
+
+  <div class="card">
+    <div class="ct">Estate reduction and transfer strategies (updated for OBBBA + WA laws)</div>
+    <div class="ri"><span class="bdg bdg-r">Urgent</span><span class="ri-t"><strong style="color:var(--text)">A/B trust (bypass trust).</strong> WA does NOT allow portability. Each spouse's $3M WA exclusion is lost if not captured in a trust. A/B trust splits estate at first death: "B" trust holds up to $3M for children (bypasses surviving spouse's estate). Combined: $6M excluded. Without it: only $3M. This single document saves ~$300k+ in WA estate tax.</span></div>
+    <div class="ri"><span class="bdg bdg-g">Start now</span><span class="ri-t"><strong style="color:var(--text)">Annual gifting (MFJ).</strong> $19k/person tax-free (2025). Both spouses give: $38k/person. To 2 children: $76k/yr. Over 10 years: $760k removed from estate. 529 superfunding: $95k per spouse per child ($380k total for 2 children), front-loading 5 years of annual exclusion gifts at once. Under OBBBA's $15M exemption, these gifts use zero federal lifetime exclusion unless you're above $15M.</span></div>
+    <div class="ri"><span class="bdg bdg-a">High value</span><span class="ri-t"><strong style="color:var(--text)">Donor-advised fund.</strong> Contribute appreciated stock → immediate federal deduction → reduces WA taxable estate → $100k deduction against WA millionaire tax. Fidelity Charitable, Schwab Charitable. "Bunching" strategy: contribute $200k in one year, take standard deduction the next — maximizes total deductions across years.</span></div>
+    <div class="ri"><span class="bdg bdg-b">Long-term</span><span class="ri-t"><strong style="color:var(--text)">Roth IRA as legacy asset.</strong> Best possible asset for heirs: 10-year tax-free distribution. Under OBBBA's permanent $15M/$30M exemption, your estate passes federal-tax-free regardless — but Roth conversions still save heirs from income tax on inherited traditional IRAs. The heirs' savings is the real win.</span></div>
+    <div class="ri"><span class="bdg bdg-p">NV strategy</span><span class="ri-t"><strong style="color:var(--text)">Nevada Incomplete Non-Grantor (NING) trust.</strong> Transfer assets to a NV trust — assets grow outside WA's taxing jurisdiction. WA's SB 6346 specifically adds back NING trust income, so this must be paired with genuine NV residency to be effective. Consult a multi-state trust attorney. If you establish NV residency, a NV dynasty trust can hold assets indefinitely with zero state estate, income, or capital gains tax.</span></div>
+    <div class="ri"><span class="bdg bdg-b">Consider</span><span class="ri-t"><strong style="color:var(--text)">Irrevocable life insurance trust (ILIT).</strong> Life insurance inside ILIT sits outside both federal and WA taxable estate. Death benefit funds the WA estate tax bill. Under OBBBA, federal ILIT need is reduced — but WA estate tax still applies, making ILIT valuable for WA residents. Get quotes now for both spouses at 51.</span></div>
+  </div>
+
+  <div class="card">
+    <div class="ct">Beneficiary designation audit — both spouses, review every 2 years</div>
+    <div class="cs">Beneficiary designations override your will entirely. Wrong designations can redirect millions to the wrong person.</div>
+    <div class="benef-g">
+      <div class="benef-c"><div class="benef-ct">Traditional 401k</div><div class="benef-cb">Spouse as primary (required by law unless waived). Trust as contingent. Heirs get 10-year taxable distribution — most tax-expensive asset to inherit. Reduce balance via Roth conversions. Both spouses' plans should mirror.</div></div>
+      <div class="benef-c"><div class="benef-ct">Roth 401k + Roth IRA</div><div class="benef-cb">Children as primary. Best asset to inherit — 10-year entirely tax-free distribution. Maximize conversions to maximize what children receive tax-free. Most valuable legacy asset.</div></div>
+      <div class="benef-c"><div class="benef-ct">Taxable brokerage</div><div class="benef-cb">WA community property: both spouses get full step-up at first death (unique to community property states). Do NOT gift appreciated stock while alive — let it pass at death for full step-up.</div></div>
+      <div class="benef-c"><div class="benef-ct">HSA</div><div class="benef-cb">Name spouse as beneficiary — inherits as an HSA, completely tax-free. Non-spouse heirs: entire HSA balance becomes taxable income in year of death. Consider spending HSA during retirement.</div></div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/expenses.html
+++ b/expenses.html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="assets/tw-reskin.css?v=1">
     <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
     <script src="assets/suite-state.js?v=8" defer></script>
-    <script src="assets/suite.js?v=13" defer></script>
+    <script src="assets/suite.js?v=14" defer></script>
     <script src="assets/adapters/expenses.js?v=1" defer></script>
 </head>
 <body class="bg-gray-100 min-h-screen">

--- a/golden_ratio_portfolio_dashboard.html
+++ b/golden_ratio_portfolio_dashboard.html
@@ -55,7 +55,7 @@ body{margin:0;font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-seri
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6"><link rel="stylesheet" href="assets/theme.css?v=1">
 <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
 <script src="assets/suite-state.js?v=8" defer></script>
-<script src="assets/suite.js?v=13" defer></script>
+<script src="assets/suite.js?v=14" defer></script>
 <script src="assets/adapters/golden.js?v=2" defer></script>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -302,7 +302,7 @@
         <span class="sb-x">Tax Plan (Estimator)</span>
         <span class="ws-badge ws-badge--q2 sb-x">Q2</span>
       </a>
-      <a class="ws-navitem" href="retirement_master_plan_2.html#est" title="Estate Plan">
+      <a class="ws-navitem" href="estate_plan.html" title="Estate Plan">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
         <span class="sb-x">Estate Plan</span>
       </a>
@@ -747,8 +747,9 @@
       'monte_carlo.html': 'Monte Carlo',
       'data_hub.html': 'Data Hub',
       'settings.html': 'Settings',
-      // Sub-hash routes: the tool page + a tab deep-link inside it
-      'retirement_master_plan_2.html#est': 'Estate Plan'
+      'estate_plan.html': 'Estate Plan'
+      // (Sub-hash routes like 'file.html#tab' remain supported —
+      // routeFromHref/resolveRoute normalize them.)
     };
     var frame = document.getElementById('ws-frame');
     var dashView = document.getElementById('ws-dash-view');

--- a/monte_carlo.html
+++ b/monte_carlo.html
@@ -108,7 +108,7 @@ body{font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-serif;backgro
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6"><link rel="stylesheet" href="assets/theme.css?v=1">
 <script src="https://d3js.org/d3.v7.min.js"></script>
 <script src="assets/suite-state.js?v=8" defer></script>
-<script src="assets/suite.js?v=13" defer></script>
+<script src="assets/suite.js?v=14" defer></script>
 <script src="assets/adapters/mc.js?v=1" defer></script>
 </head>
 <body>

--- a/net_worth.html
+++ b/net_worth.html
@@ -129,7 +129,7 @@ body{font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-serif;backgro
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6"><link rel="stylesheet" href="assets/theme.css?v=1">
 <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
 <script src="assets/suite-state.js?v=8" defer></script>
-<script src="assets/suite.js?v=13" defer></script>
+<script src="assets/suite.js?v=14" defer></script>
 <script src="assets/adapters/networth.js?v=1" defer></script>
 </head>
 <body>

--- a/portfolio_review.html
+++ b/portfolio_review.html
@@ -117,7 +117,7 @@ body{font-family:'Inter',sans-serif;background:var(--bg);color:var(--text);font-
 <link rel="stylesheet" href="assets/theme.css?v=1">
 <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
 <script src="assets/suite-state.js?v=8" defer></script>
-<script src="assets/suite.js?v=13" defer></script>
+<script src="assets/suite.js?v=14" defer></script>
 <script src="assets/adapters/portfolio.js?v=6" defer></script>
 </head>
 <body>

--- a/portfolio_tracker.html
+++ b/portfolio_tracker.html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="assets/tw-reskin.css?v=1">
     <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
     <script src="assets/suite-state.js?v=8" defer></script>
-    <script src="assets/suite.js?v=13" defer></script>
+    <script src="assets/suite.js?v=14" defer></script>
     <script src="assets/adapters/tracker.js?v=1" defer></script>
 </head>
 <body class="bg-gray-100 min-h-screen">

--- a/retirement_master_plan_2.html
+++ b/retirement_master_plan_2.html
@@ -161,7 +161,7 @@ body{font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-serif;backgro
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6"><link rel="stylesheet" href="assets/theme.css?v=1">
 <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
 <script src="assets/suite-state.js?v=8" defer></script>
-<script src="assets/suite.js?v=13" defer></script>
+<script src="assets/suite.js?v=14" defer></script>
 <script src="assets/adapters/retirement.js?v=6" defer></script>
 </head>
 <body>
@@ -184,8 +184,8 @@ body{font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-serif;backgro
   <button class="nb" onclick="showTab('proj',this)">Projection</button>
   <button class="nb" onclick="showTab('roth',this)">Roth + SS</button>
   <button class="nb" onclick="showTab('tax',this)">Tax strategy</button>
-  <!-- Estate plan moved to its own sidebar entry — pane #est stays,
-       reached via the #est hash (see activateTabFromHash) -->
+  <!-- Estate plan extracted to its own page: estate_plan.html -->
+
   <button class="nb" onclick="showTab('rmd',this)">RMD calculator</button>
   <button class="nb" onclick="showTab('tl',this)">Timeline</button>
 </div>
@@ -442,131 +442,6 @@ body{font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-serif;backgro
     <div class="ri"><span class="bdg bdg-g">Recommended: Hybrid LTC</span><span class="ri-t">Life insurance + LTC rider (Lincoln MoneyGuard, Nationwide CareMatters, OneAmerica Asset Care). $200–250k single premium per spouse buys $600k–$1M in LTC benefits each. If unused, heirs receive death benefit. Buy both policies at 51.</span></div>
     <div class="ri"><span class="bdg bdg-a">Self-insure gap</span><span class="ri-t">Alzheimer's care at $10–15k/month for 8–10 years = $960k–$1.8M per spouse. Two spouses doubles the tail risk. Insure years 2+ for both, self-fund year 1.</span></div>
     <div class="ri"><span class="bdg bdg-b">Tax angle</span><span class="ri-t">Qualified LTC premiums deductible as medical (above 7.5% AGI MFJ). HSA funds pay LTC insurance premiums tax-free after 65. OBBBA's Medicaid changes (2028+) include $1M home equity cap for eligibility — plan accordingly.</span></div>
-  </div>
-</div>
-
-<!-- ESTATE PLAN -->
-<div id="est" class="pane">
-  <div class="card" style="border-color:var(--blue)">
-    <div class="ct" style="color:var(--blue)">OBBBA (signed July 4, 2025) — federal estate tax permanently resolved</div>
-    <div class="cs">The One Big Beautiful Bill Act permanently raised the federal estate/gift/GST exemption. No more sunset anxiety.</div>
-    <div class="g4">
-      <div class="sc"><div class="sc-l">Federal exemption (2026+)</div><div class="sc-v g">$15M</div></div>
-      <div class="sc"><div class="sc-l">MFJ combined (portability)</div><div class="sc-v g">$30M</div></div>
-      <div class="sc"><div class="sc-l">Your est. estate</div><div class="sc-v">$3.5M+</div></div>
-      <div class="sc"><div class="sc-l">Federal estate tax due</div><div class="sc-v g">$0</div></div>
-    </div>
-    <div class="ib ib-g">At $3.5M, you are well below the $30M MFJ federal exemption. Federal estate tax is permanently a non-issue for your estate. However, the exemption is indexed to inflation from 2027 — file portability election on first spouse's death (IRS Form 706) to preserve the deceased spouse's unused exclusion. This is free insurance even when clearly under the limit.</div>
-  </div>
-
-  <div class="card" style="border-color:var(--red)">
-    <div class="ct" style="color:var(--red)">WA state estate tax — SB 6347 (updated rates, effective July 2026)</div>
-    <div class="cs">WA estate tax is separate from federal. New SB 6347 restores pre-2025 rates (top rate: 20%, down from 35%). $3M exclusion retained, NOT indexed for inflation.</div>
-    <div class="g4">
-      <div class="sc"><div class="sc-l">WA exclusion</div><div class="sc-v">$3.0M</div></div>
-      <div class="sc"><div class="sc-l">Your estate</div><div class="sc-v a">$3.5M+</div></div>
-      <div class="sc"><div class="sc-l">WA taxable excess</div><div class="sc-v a">~$0.5M</div></div>
-      <div class="sc"><div class="sc-l">Est. WA estate tax</div><div class="sc-v a">~$50k</div></div>
-    </div>
-    <div class="ib ib-r">WA estate tax rates run 10–20% on the excess above $3M. The $3M exclusion does NOT adjust for inflation and WA does NOT allow portability between spouses — each spouse needs their own $3M exclusion via proper trust planning (A/B trust). Without an A/B trust, only one $3M exclusion is available. With proper planning: $6M combined exclusion means you pay little to no WA estate tax at $3.5M. But as your estate grows past $6M, this protection erodes.</div>
-  </div>
-
-  <div class="card" style="border-color:var(--red)">
-    <div class="ct" style="color:var(--red)">WA millionaire tax — SB 6346 (effective Jan 1, 2028)</div>
-    <div class="cs">9.9% tax on WA household income exceeding $1M/year. Applies to residents, part-year residents, and nonresidents with WA-source income. First returns due April 2029.</div>
-    <div class="ri"><span class="bdg bdg-r">Critical</span><span class="ri-t"><strong style="color:var(--text)">$1M threshold per household, NOT per person.</strong> Unlike federal MFJ, the $1M is not doubled for married couples. Large Roth conversions, capital gains from buffer replenishment, or RMDs could push you over $1M in any given year. At $250k spend + $150k Roth conversion + $100k cap gains = $500k — safe. But large one-time events (property sale, stock windfall) could trigger it.</span></div>
-    <div class="ri"><span class="bdg bdg-a">Planning</span><span class="ri-t"><strong style="color:var(--text)">Roth conversion pacing matters.</strong> Converting $350k/yr is safe if total household income stays under $1M. But if combined with dividends, capital gains, and other income, you could inadvertently cross the $1M line. Model total AGI before each year's conversion.</span></div>
-    <div class="ri"><span class="bdg bdg-b">Credits</span><span class="ri-t"><strong style="color:var(--text)">Offsetting credits available:</strong> WA capital gains tax credit (avoids double-tax on same income), B&O tax credit, other state income tax credit (OSTC) if you have income taxed in another state. Charitable deduction up to $100k against WA taxable income. Pass-through entity tax (PTET) election available for business owners.</span></div>
-    <div class="ri"><span class="bdg bdg-r">Legal risk</span><span class="ri-t"><strong style="color:var(--text)">Constitutionality uncertain.</strong> Legal challenges are underway — WA Supreme Court has granted accelerated review in Heywood v. Hobbs. The tax may be struck down or modified. However, plan as if it will survive — don't rely on litigation outcomes for financial planning.</span></div>
-    <div class="ib ib-a">The combination of WA's 9.9% millionaire tax, 7% capital gains tax, and 10–20% estate tax makes WA one of the most aggressive state tax environments for high-net-worth retirees. NV residency eliminates all three. See the WA vs NV comparison table below.</div>
-  </div>
-
-  <div class="card">
-    <div class="ct">WA vs NV — state residency strategy matrix (today's $ at retirement)</div>
-    <div class="cs">20-year cumulative tax impact comparison. NV has zero income tax, zero capital gains tax, zero estate tax.</div>
-    <table class="cmp-tbl">
-      <thead>
-        <tr>
-          <th>Wealth tier</th>
-          <th>WA strategy</th>
-          <th>NV strategy</th>
-          <th>20-yr delta (vs NV)</th>
-          <th>Recommendation</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>&lt;$5M</td>
-          <td>A/B trust; protect WA $3M exclusion per spouse</td>
-          <td>Not needed</td>
-          <td style="font-weight:600;color:var(--green)">$0–$300k</td>
-          <td>Keep it simple — focus on WA estate planning, not relocation</td>
-        </tr>
-        <tr>
-          <td>$5M–$10M</td>
-          <td>A/B trust + optimize taxes; annual gifting</td>
-          <td>Selective trust</td>
-          <td style="font-weight:600;color:var(--amber)">$300k–$1.2M</td>
-          <td>Consider NV only if large liquidity event is coming or millionaire tax applies</td>
-        </tr>
-        <tr style="background:var(--blue-bg)">
-          <td style="color:var(--blue-t)">$3.5M ← you</td>
-          <td style="color:var(--blue-t)">A/B trust + Roth conversions + DAF; WA estate tax ~$50k with proper trust; millionaire tax ~$0 if income managed below $1M</td>
-          <td style="color:var(--blue-t)">NV trust optional; mainly benefit if large liquidity events or estate growth expected</td>
-          <td style="font-weight:600;color:var(--blue-t)">$0–$300k</td>
-          <td style="color:var(--blue-t)"><strong>Focus on WA A/B trust — NV residency not needed at this estate size unless large capital events are planned</strong></td>
-        </tr>
-        <tr>
-          <td>$10M–$20M</td>
-          <td>A/B + optimize; income + estate tax drag meaningful</td>
-          <td>Trust + consider move</td>
-          <td style="font-weight:600;color:var(--red)">$1.2M–$4M</td>
-          <td>Start NV trust now; plan relocation before major gains events</td>
-        </tr>
-        <tr>
-          <td>$20M–$40M</td>
-          <td>Income + estate tax drag very high</td>
-          <td>Trust + move</td>
-          <td style="font-weight:600;color:var(--red)">$4M–$10M</td>
-          <td>Execute NV trust immediately and plan a clean residency move</td>
-        </tr>
-        <tr>
-          <td>$40M+</td>
-          <td>Very high compounding leakage across all WA taxes</td>
-          <td>Core NV strategy</td>
-          <td style="font-weight:600;color:var(--red)">$10M–$50M+</td>
-          <td>Make NV your base — full trust + residency strategy is essential</td>
-        </tr>
-      </tbody>
-    </table>
-    <div class="ib ib-b" style="margin-top:14px"><strong>NV residency requirements for WA residents:</strong> (1) Establish genuine physical presence — spend 183+ days/yr in NV; (2) Get NV driver's license, voter registration, vehicle registration; (3) Change bank accounts, doctors, mail; (4) Sever WA domicile indicators — WA will audit aggressively, especially after SB 6346; (5) Consider purchasing or leasing NV property (Reno/Las Vegas/Henderson); (6) Timing: complete the move before Jan 1, 2028 to avoid the first year of WA millionaire tax. Note: WA SB 6346 also taxes nonresidents on WA-source income — if you retain WA rental property, business interests, or employment compensation, those remain taxable.</div>
-  </div>
-
-  <div class="card">
-    <div class="ct">What is estate and beneficiary coordination?</div>
-    <div style="font-size:13px;color:var(--muted);line-height:1.8;margin-bottom:12px">It means aligning three things: (1) how assets are <strong style="color:var(--text)">titled</strong> (community property vs. separate in WA), (2) <strong style="color:var(--text)">beneficiary designations</strong> on accounts (these override your will entirely), and (3) <strong style="color:var(--text)">estate documents</strong> (A/B trust, wills, POAs, healthcare directives for both spouses). A mismatch between any of these can send assets to the wrong person, trigger large taxes, or tie assets up in probate for years.</div>
-    <div style="font-size:13px;color:var(--muted);line-height:1.8"><strong style="color:var(--text)">SECURE Act 2.0 impact:</strong> Non-spouse beneficiaries who inherit a traditional IRA must withdraw everything within 10 years and pay ordinary income tax. A $2M traditional IRA to children = $400–600k+ in taxes. A $2M <em>Roth</em> IRA to children = zero tax, same 10-year window. This single difference justifies the entire Roth conversion strategy.</div>
-  </div>
-
-  <div class="card">
-    <div class="ct">Estate reduction and transfer strategies (updated for OBBBA + WA laws)</div>
-    <div class="ri"><span class="bdg bdg-r">Urgent</span><span class="ri-t"><strong style="color:var(--text)">A/B trust (bypass trust).</strong> WA does NOT allow portability. Each spouse's $3M WA exclusion is lost if not captured in a trust. A/B trust splits estate at first death: "B" trust holds up to $3M for children (bypasses surviving spouse's estate). Combined: $6M excluded. Without it: only $3M. This single document saves ~$300k+ in WA estate tax.</span></div>
-    <div class="ri"><span class="bdg bdg-g">Start now</span><span class="ri-t"><strong style="color:var(--text)">Annual gifting (MFJ).</strong> $19k/person tax-free (2025). Both spouses give: $38k/person. To 2 children: $76k/yr. Over 10 years: $760k removed from estate. 529 superfunding: $95k per spouse per child ($380k total for 2 children), front-loading 5 years of annual exclusion gifts at once. Under OBBBA's $15M exemption, these gifts use zero federal lifetime exclusion unless you're above $15M.</span></div>
-    <div class="ri"><span class="bdg bdg-a">High value</span><span class="ri-t"><strong style="color:var(--text)">Donor-advised fund.</strong> Contribute appreciated stock → immediate federal deduction → reduces WA taxable estate → $100k deduction against WA millionaire tax. Fidelity Charitable, Schwab Charitable. "Bunching" strategy: contribute $200k in one year, take standard deduction the next — maximizes total deductions across years.</span></div>
-    <div class="ri"><span class="bdg bdg-b">Long-term</span><span class="ri-t"><strong style="color:var(--text)">Roth IRA as legacy asset.</strong> Best possible asset for heirs: 10-year tax-free distribution. Under OBBBA's permanent $15M/$30M exemption, your estate passes federal-tax-free regardless — but Roth conversions still save heirs from income tax on inherited traditional IRAs. The heirs' savings is the real win.</span></div>
-    <div class="ri"><span class="bdg bdg-p">NV strategy</span><span class="ri-t"><strong style="color:var(--text)">Nevada Incomplete Non-Grantor (NING) trust.</strong> Transfer assets to a NV trust — assets grow outside WA's taxing jurisdiction. WA's SB 6346 specifically adds back NING trust income, so this must be paired with genuine NV residency to be effective. Consult a multi-state trust attorney. If you establish NV residency, a NV dynasty trust can hold assets indefinitely with zero state estate, income, or capital gains tax.</span></div>
-    <div class="ri"><span class="bdg bdg-b">Consider</span><span class="ri-t"><strong style="color:var(--text)">Irrevocable life insurance trust (ILIT).</strong> Life insurance inside ILIT sits outside both federal and WA taxable estate. Death benefit funds the WA estate tax bill. Under OBBBA, federal ILIT need is reduced — but WA estate tax still applies, making ILIT valuable for WA residents. Get quotes now for both spouses at 51.</span></div>
-  </div>
-
-  <div class="card">
-    <div class="ct">Beneficiary designation audit — both spouses, review every 2 years</div>
-    <div class="cs">Beneficiary designations override your will entirely. Wrong designations can redirect millions to the wrong person.</div>
-    <div class="benef-g">
-      <div class="benef-c"><div class="benef-ct">Traditional 401k</div><div class="benef-cb">Spouse as primary (required by law unless waived). Trust as contingent. Heirs get 10-year taxable distribution — most tax-expensive asset to inherit. Reduce balance via Roth conversions. Both spouses' plans should mirror.</div></div>
-      <div class="benef-c"><div class="benef-ct">Roth 401k + Roth IRA</div><div class="benef-cb">Children as primary. Best asset to inherit — 10-year entirely tax-free distribution. Maximize conversions to maximize what children receive tax-free. Most valuable legacy asset.</div></div>
-      <div class="benef-c"><div class="benef-ct">Taxable brokerage</div><div class="benef-cb">WA community property: both spouses get full step-up at first death (unique to community property states). Do NOT gift appreciated stock while alive — let it pass at death for full step-up.</div></div>
-      <div class="benef-c"><div class="benef-ct">HSA</div><div class="benef-cb">Name spouse as beneficiary — inherits as an HSA, completely tax-free. Non-spouse heirs: entire HSA balance becomes taxable income in year of death. Consider spending HSA during retirement.</div></div>
-    </div>
   </div>
 </div>
 

--- a/roth_conversion.html
+++ b/roth_conversion.html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="assets/tw-reskin.css?v=1">
     <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
     <script src="assets/suite-state.js?v=8" defer></script>
-    <script src="assets/suite.js?v=13" defer></script>
+    <script src="assets/suite.js?v=14" defer></script>
     <script src="assets/adapters/roth.js?v=1" defer></script>
 </head>
 <body class="bg-gray-100 min-h-screen">

--- a/settings.html
+++ b/settings.html
@@ -268,7 +268,7 @@
 
 </div>
 
-<script src="assets/suite.js?v=13" defer></script>
+<script src="assets/suite.js?v=14" defer></script>
 <script src="assets/suite-state.js?v=8" defer></script>
 <script>
 (function () {

--- a/social_security.html
+++ b/social_security.html
@@ -115,7 +115,7 @@ input[type=range]::-moz-range-thumb{width:24px;height:24px;border-radius:50%;bac
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6"><link rel="stylesheet" href="assets/theme.css?v=1">
 <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
 <script src="assets/suite-state.js?v=8" defer></script>
-<script src="assets/suite.js?v=13" defer></script>
+<script src="assets/suite.js?v=14" defer></script>
 <script src="assets/adapters/ss.js?v=1" defer></script>
 </head>
 <body>


### PR DESCRIPTION
Follow-up to #25 — the sub-hash deep link still rendered the estate content **inside** the Retirement Master Plan shell (its banner + other tabs were visible). Estate Plan is now a true standalone page.

## What changed
- **`estate_plan.html` (NEW)** — the `#est` pane moved out of the retirement tool verbatim, wrapped with a copy of that tool's stylesheet, its own green header banner (Fed exemption $30M / WA exclusion $3M / est. WA tax ~$50k), and the standard suite chrome. No adapter (static analysis content).
- **`retirement_master_plan_2.html`** — estate pane removed entirely; tab bar is now Overview / 3-yr buffer / Projection / Roth+SS / Tax strategy / RMD / Timeline. Hash-tab deep links from #25 remain for the other tabs.
- **Router/sidebar** — Estate Plan → `estate_plan.html` (plain route; the sub-hash mechanism stays available but unused).
- **`suite.js` v13 → v14** (all pages) — Estate Plan added to the Retirement cluster, so the standalone topnav shows **Master Plan / Estate Plan / Monte Carlo**.

## Verified (headless Chrome)
- In-shell `#estate_plan.html`: only the estate page renders (own banner, **no retirement tabs**), sidebar Estate Plan active, title correct.
- Standalone: Retirement cluster sub-nav with Estate Plan active.
- Retirement page: tabs `[Overview, 3-yr buffer, Projection, Roth + SS, Tax strategy, RMD calculator, Timeline]`, switching works, `est` pane gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)