### PR TITLE
Consume Settings preferences across shell + tools (Phase 13n)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -520,6 +520,42 @@ Phase 13m (Estate Plan extracted to a standalone page):
   millionaire tax, trust strategy, beneficiary audit) — candidates for
   store-driven figures later (estate size from net worth, etc.).
 
+Phase 13n (step 4 — Settings preferences consumed by shell + tools):
+- `assets/suite.js?v=15` (ALL tool pages + data_hub + settings): new
+  shared helpers `WealthSuite.fmtMoney(n)` (honours
+  `preferences.currencyFormat` — 'full' → exact dollars, else compact)
+  and `WealthSuite.activeScenario()` (activeScenarioId match, else
+  first stored — mirrors Settings' fallback; null = implicit "Base
+  case"). `renderHouseholdBanner` formats via fmtMoney, appends the
+  active scenario name, and "retire in N yrs" honours the scenario's
+  targetRetireAge override.
+- `index.html`: profile-chip sub line = active scenario name · filing
+  · taxYear ("Base case" when none stored). Alert prefs consumed:
+  `alerts.quarterlyTax === false` hides the Q2 tax banner (Dismiss is
+  a this-visit hide on top); `alerts.staleData`/`staleDays` turn the
+  "live from your data" note into "· last updated N days ago" (warn)
+  when `meta.lastUpdated` is older than the threshold. `money()`
+  honours currencyFormat 'full' in KPI tiles/legends/stat tiles; chart
+  axes stay compact via `moneyC()`. **Fixed a real re-render bug**:
+  the dashboard called `store.subscribe(refreshAll)` but the API is
+  `subscribe(path, fn)` (registration landed as key=fn, cb=undefined),
+  and the DOMContentLoaded boot path — the one that actually runs,
+  since suite-state.js is a defer script loaded after the inline shell
+  — never subscribed at all. Cross-document store edits now repaint
+  the dashboard live (verified headless via storage event).
+- `assets/adapters/roth.js?v=2`: retireAge prefers the active
+  scenario; `preferences.fedBracket` seeds the "fill through bracket"
+  select, snapped to the tool's 12/22/24/32 options (35%+ caps at 32).
+  `roth_conversion.html`'s `__rothSeed` hook accepts `targetBracket`.
+- `assets/adapters/mc.js?v=2`: retire age prefers the active scenario;
+  a scenario `withdrawalRate` > 0 overrides the withdrawal with
+  rate% × starting balance.
+- Asset & Cap-Gains deliberately unchanged: it has no bracket input
+  (it computes marginal rates progressively from income), so
+  fedBracket has nothing to default there.
+- currencyFormat coverage = dashboard + the household banner on every
+  tool page; tools' own internals keep their native formatters.
+
 ## Constraints to preserve
 
 - **Zero build step.** No Vite/Webpack until scope demands it.

--- a/TaxAssetCalcv4.html
+++ b/TaxAssetCalcv4.html
@@ -37,7 +37,7 @@
     <link rel="stylesheet" href="assets/tw-reskin.css?v=1">
     <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
     <script src="assets/suite-state.js?v=8" defer></script>
-    <script src="assets/suite.js?v=14" defer></script>
+    <script src="assets/suite.js?v=15" defer></script>
     <script src="assets/adapters/asset.js?v=5" defer></script>
 </head>
 <body class="bg-gray-100 flex items-center justify-center min-h-screen py-8">

--- a/TaxEstimatorV5.html
+++ b/TaxEstimatorV5.html
@@ -22,7 +22,7 @@
   <link rel="stylesheet" href="assets/tw-reskin.css?v=1">
   <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
   <script src="assets/suite-state.js?v=8" defer></script>
-  <script src="assets/suite.js?v=14" defer></script>
+  <script src="assets/suite.js?v=15" defer></script>
   <script src="assets/adapters/tax.js?v=5" defer></script>
 </head>
 <body class="bg-slate-50">

--- a/assets/adapters/mc.js
+++ b/assets/adapters/mc.js
@@ -5,10 +5,12 @@
  * store on load. No write-back — simulation results are ephemeral.
  *
  * Starting balance: portfolio.totalValue + retirement.balances.total
- * Withdrawal:       retirement.plan.annualExpenses
+ * Withdrawal:       retirement.plan.annualExpenses, overridden by the
+ *                   active scenario's withdrawalRate × starting balance
  * Mean return:      retirement.plan.growthAssumption
  * Current age:      min(household.spouses[*].age)
- * Retire age:       retirement.plan.targetRetireAge
+ * Retire age:       active scenario's targetRetireAge, else
+ *                   retirement.plan.targetRetireAge
  * ============================================================= */
 (function () {
   'use strict';
@@ -34,15 +36,29 @@
 
     const portVal    = Number((state.portfolio  && state.portfolio.totalValue)                       || 0);
     const retireBal  = Number((state.retirement && state.retirement.balances && state.retirement.balances.total) || 0);
-    const retireAge  = state.retirement && state.retirement.plan && state.retirement.plan.targetRetireAge;
     const expenses   = state.retirement && state.retirement.plan && state.retirement.plan.annualExpenses;
     const growthRate = state.retirement && state.retirement.plan && state.retirement.plan.growthAssumption;
 
+    // Active scenario (Settings) overrides plan retire age; its
+    // withdrawalRate (% of starting balance) overrides annualExpenses.
+    const prefs = state.preferences || {};
+    const scenarios = prefs.scenarios || [];
+    const scn = scenarios.length
+      ? (scenarios.find(s => s && s.id === prefs.activeScenarioId) || scenarios[0])
+      : null;
+    const retireAge = (scn && Number(scn.targetRetireAge))
+      || (state.retirement && state.retirement.plan && state.retirement.plan.targetRetireAge);
+
     const combined = portVal + retireBal;
+
+    let withdraw = expenses > 0 ? expenses : null;
+    if (scn && Number(scn.withdrawalRate) > 0 && combined > 0) {
+      withdraw = Math.round(combined * Number(scn.withdrawalRate) / 100);
+    }
 
     window._mcTool.setParams({
       balance:  combined  > 0 ? combined  : null,
-      withdraw: expenses  > 0 ? expenses  : null,
+      withdraw: withdraw,
       ret:      growthRate > 0 ? growthRate : null,
       cAge:     currentAge,
       rAge:     retireAge,

--- a/assets/adapters/roth.js
+++ b/assets/adapters/roth.js
@@ -4,6 +4,11 @@
  * Read-only seed: pulls household data from the suite store and
  * calls window.__rothSeed (registered by the React component after
  * mount) to pre-fill the form. No writeback in v1.
+ *
+ * v2: consumes Settings preferences — the active scenario's
+ * targetRetireAge overrides the plan's, and preferences.fedBracket
+ * defaults the "fill through bracket" select (snapped to the tool's
+ * 12/22/24/32 options).
  * ============================================================= */
 (function () {
   'use strict';
@@ -37,12 +42,24 @@
 
     const filingStatus = hh.filingStatus === 'mfj' ? 'married' : 'single';
 
+    const prefs = state.preferences || {};
+    const scenarios = prefs.scenarios || [];
+    const scn = scenarios.length
+      ? (scenarios.find(s => s && s.id === prefs.activeScenarioId) || scenarios[0])
+      : null;
+
+    // Tool's select only offers 12/22/24/32 — snap to the highest option
+    // at or below the configured bracket (35%+ households still cap at 32).
+    const fed = Number(prefs.fedBracket) || 0;
+    const targetBracket = fed ? ([32, 24, 22, 12].find(b => b <= fed) || 12) : null;
+
     return {
       filingStatus,
       currentAge,
-      retireAge:    plan.targetRetireAge || null,
+      retireAge:    (scn && Number(scn.targetRetireAge)) || plan.targetRetireAge || null,
       tradBalance:  balances.total       || null,
       currentIncome: ordinaryIncome,
+      targetBracket,
     };
   }
 

--- a/assets/suite.js
+++ b/assets/suite.js
@@ -326,6 +326,41 @@
     injectTopbarIfMissing();
   }
 
+  // ---------- Shared preference helpers ----------
+  // fmtMoney: money formatter that honours preferences.currencyFormat
+  // ('full' → "$1,234,567"; anything else → compact "$1.2M"/"$123K").
+  function fmtMoney(n) {
+    n = Number(n) || 0;
+    try {
+      var store = window.WealthSuite && window.WealthSuite.store;
+      if (store && store.get('preferences.currencyFormat') === 'full') {
+        return '$' + Math.round(n).toLocaleString('en-US');
+      }
+    } catch (e) {}
+    var a = Math.abs(n);
+    if (a >= 1e6) return '$' + (n / 1e6).toFixed(1) + 'M';
+    if (a >= 1e3) return '$' + Math.round(n / 1e3) + 'K';
+    return '$' + Math.round(n);
+  }
+
+  // activeScenario: the scenario Settings marked active (or the first
+  // stored one, matching Settings' own fallback). Null when none stored —
+  // callers treat that as the implicit "Base case" (= plan values as-is).
+  function activeScenario() {
+    try {
+      var store = window.WealthSuite && window.WealthSuite.store;
+      if (!store) return null;
+      var p = store.get('preferences') || {};
+      var list = p.scenarios || [];
+      if (!list.length) return null;
+      var hit = null;
+      for (var i = 0; i < list.length; i++) {
+        if (list[i] && list[i].id === p.activeScenarioId) hit = list[i];
+      }
+      return hit || list[0];
+    } catch (e) { return null; }
+  }
+
   // ---------- Shared household banner ----------
   // Adapters call WealthSuite.renderHouseholdBanner(opts) instead of
   // reimplementing the create/update logic themselves.
@@ -344,9 +379,7 @@
     function fmtM(n) {
       n = Number(n);
       if (!n || !isFinite(n)) return null;
-      if (n >= 1e6) return '$' + (n / 1e6).toFixed(1) + 'M';
-      if (n >= 1e3) return '$' + Math.round(n / 1e3) + 'K';
-      return '$' + Math.round(n);
+      return fmtMoney(n);
     }
     function sumSp(o) {
       return o ? (Number(o.s1) || 0) + (Number(o.s2) || 0) : 0;
@@ -364,7 +397,8 @@
                       + sumSp(c.catchup) + sumSp(c.ira) + (Number(c.hsa) || 0);
     var portVal       = state.portfolio && state.portfolio.totalValue;
     var expenses      = plan.annualExpenses;
-    var retireAge     = plan.targetRetireAge;
+    var scn           = activeScenario();
+    var retireAge     = (scn && Number(scn.targetRetireAge)) || plan.targetRetireAge;
     var ages          = spouses.map(function(s) {
       return (s && s.age != null && s.age !== '') ? String(s.age) : null;
     }).filter(Boolean);
@@ -387,6 +421,8 @@
     var fields = (opts && opts.fields) || [];
     var parts  = fields.map(function(f) { return COMPUTED[f]; }).filter(Boolean);
     if (!parts.length) return;
+
+    if (scn && scn.name) parts.push('scenario “' + scn.name + '”');
 
     var banner = document.getElementById('suite-household-banner');
     if (!banner) {
@@ -425,5 +461,7 @@
     modules: MODULES.slice(),
     clusters: CLUSTERS.map(c => ({ id: c.id, label: c.label, tools: c.tools.slice() })),
     renderHouseholdBanner,
+    fmtMoney,
+    activeScenario,
   });
 })();

--- a/data_hub.html
+++ b/data_hub.html
@@ -303,7 +303,7 @@ AAPL,50,142.80,Schwab 401(k)"></textarea>
 
 </div>
 
-<script src="assets/suite.js?v=14" defer></script>
+<script src="assets/suite.js?v=15" defer></script>
 <script src="assets/suite-state.js?v=8" defer></script>
 <script>
 (function () {

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,28 +1,21 @@
 # Wealth Suite — Backlog
 
-*Updated 2026-07-02, after Release 5 (design handoff complete through Phase 13m — see `docs/releases/release-5.md` and CLAUDE.md Phase 13 log). `main` at `b93fc67`. This file is the resume point: pick the top unchecked item unless directed otherwise.*
+*Updated 2026-07-08, after Phase 13n (Settings preferences consumed — see CLAUDE.md Phase 13 log). This file is the resume point: pick the top unchecked item unless directed otherwise.*
 
 ## Up next (roughly by value)
 
-1. **Tools consuming preferences** — individual tools should read from the store:
-   - active scenario assumptions (`preferences.scenarios[]` / `activeScenarioId`) — retirement/Monte Carlo/Roth inputs
-   - `preferences.fedBracket` — Roth Conversion + Asset & Cap-Gains defaults
-   - `preferences.currencyFormat` (compact vs full) — dashboard + tool displays
-   - alert prefs (`preferences.alerts.*`) driving the Q2 tax banner + stale-data badges (thresholds exist in Settings; nothing reads them yet)
-   - active scenario name in the shell's top-bar profile chip (currently static "Scenario A · 2026"-style)
-
-2. **Data Hub polish**
+1. **Data Hub polish**
    - column-mapping editor UI ("Edit mapping" in the import preview — currently auto-map only)
    - in-hub "Refresh Prices" (currently a stub pointing at the Portfolio Tracker; reuse its quote-worker fetch)
    - in-hub expense CSV parsing (currently links out to the Expense Tracker)
 
-3. **Estate Plan live figures** — `estate_plan.html` is static analysis text; compute estate size / WA taxable excess / est. tax from Net Worth data in the store.
+2. **Estate Plan live figures** — `estate_plan.html` is static analysis text; compute estate size / WA taxable excess / est. tax from Net Worth data in the store.
 
-4. **Site Map page** — sidebar "Review → Site Map" is a non-navigating "Soon" chip; build per `Site Map.dc.html` in the design handoff bundle.
+3. **Site Map page** — sidebar "Review → Site Map" is a non-navigating "Soon" chip; build per `Site Map.dc.html` in the design handoff bundle.
 
-5. **AI chat re-homing** — `assets/ai/chat.js` + `briefing.js` still exist but nothing loads them since the shell rebuild. Decide: chat panel inside the shell? Delete briefing?
+4. **AI chat re-homing** — `assets/ai/chat.js` + `briefing.js` still exist but nothing loads them since the shell rebuild. Decide: chat panel inside the shell? Delete briefing?
 
-6. **Retirement Master Plan hardcoded numbers** — the tool's banner/projections use hardcoded figures ($1.35M, age 45, $90k spend); its adapter seeds some, but a fuller store-driven pass is pending (handoff step 4 for tools).
+5. **Retirement Master Plan hardcoded numbers** — the tool's banner/projections use hardcoded figures ($1.35M, age 45, $90k spend); its adapter seeds some, but a fuller store-driven pass is pending (handoff step 4 for tools).
 
 ## Known issues / watchlist
 - **TaxAssetCalcv4 renders blank in *headless* Chrome** (Babel+D3 vs virtual-time). Fine in real browsers since the 7.29.7 pin. Don't chase it in headless tests.
@@ -36,4 +29,5 @@
 - Cloudflare Pages + Access privacy migration (see memory: quote-infra-and-privacy-plan)
 
 ## Done recently (context for resuming)
+- Phase 13n: Settings prefs consumed — active scenario (name in profile chip + household banners, retire-age/withdrawal overrides in Roth/MC adapters), fedBracket → Roth target bracket, currencyFormat (dashboard + banners), alert prefs (Q2 banner toggle, stale-data note). Also fixed the dashboard's broken store.subscribe (never re-rendered live before). Asset Calc has no bracket input — nothing to default there.
 - Release 5: theme → shell → single-window nav → Data Hub (schema v5) → Settings → fully live dashboard → Tailwind reskin → Babel-pin fix → Estate Plan standalone. All PRs #12–#26 merged; linear history on `main`.

--- a/estate_plan.html
+++ b/estate_plan.html
@@ -164,7 +164,7 @@ body{font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-serif;backgro
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6"><link rel="stylesheet" href="assets/theme.css?v=1">
 <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
 <script src="assets/suite-state.js?v=8" defer></script>
-<script src="assets/suite.js?v=14" defer></script>
+<script src="assets/suite.js?v=15" defer></script>
 </head>
 <body>
 

--- a/expenses.html
+++ b/expenses.html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="assets/tw-reskin.css?v=1">
     <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
     <script src="assets/suite-state.js?v=8" defer></script>
-    <script src="assets/suite.js?v=14" defer></script>
+    <script src="assets/suite.js?v=15" defer></script>
     <script src="assets/adapters/expenses.js?v=1" defer></script>
 </head>
 <body class="bg-gray-100 min-h-screen">

--- a/golden_ratio_portfolio_dashboard.html
+++ b/golden_ratio_portfolio_dashboard.html
@@ -55,7 +55,7 @@ body{margin:0;font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-seri
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6"><link rel="stylesheet" href="assets/theme.css?v=1">
 <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
 <script src="assets/suite-state.js?v=8" defer></script>
-<script src="assets/suite.js?v=14" defer></script>
+<script src="assets/suite.js?v=15" defer></script>
 <script src="assets/adapters/golden.js?v=2" defer></script>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -885,12 +885,22 @@
     var dEl = document.getElementById('ws-date');
     if (dEl) dEl.textContent = now.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
 
-    // ---- Tax alert dismiss ----
+    // ---- Tax alert dismiss + Settings alert prefs ----
+    // preferences.alerts.quarterlyTax === false hides the banner entirely;
+    // Dismiss stays a this-visit-only hide on top of that.
+    var taxDismissed = false;
     var dismiss = document.getElementById('ws-tax-dismiss');
     if (dismiss) dismiss.addEventListener('click', function () {
+      taxDismissed = true;
       var a = document.getElementById('ws-tax-alert');
       if (a) a.style.display = 'none';
     });
+    function applyAlertPrefs(s) {
+      var el = document.getElementById('ws-tax-alert');
+      if (!el) return;
+      var a = (s && s.preferences && s.preferences.alerts) || {};
+      el.style.display = (a.quarterlyTax === false || taxDismissed) ? 'none' : '';
+    }
 
     // ---- Performance table ----
     // Renders the sample immediately; refreshPerformance() (called from
@@ -1090,9 +1100,21 @@
         var st = (hh.location && hh.location.state) || 'WA';
         var yr = (s && s.preferences && s.preferences.taxYear) || now.getFullYear();
         var ini = initials(spouses);
+        // Active scenario (Settings) leads the sub line; falls back to the
+        // implicit "Base case" when none is stored.
+        var prefs = (s && s.preferences) || {};
+        var scnList = prefs.scenarios || [];
+        var scn = null;
+        if (scnList.length) {
+          for (var si = 0; si < scnList.length; si++) { if (scnList[si] && scnList[si].id === prefs.activeScenarioId) scn = scnList[si]; }
+          scn = scn || scnList[0];
+        }
+        var scnName = (scn && scn.name) || 'Base case';
         var set = function (id, val) { var el = document.getElementById(id); if (el) el.textContent = val; };
         set('ws-profile-name', name);
-        set('ws-profile-sub', filing + ' · ' + st + ' · ' + yr);
+        set('ws-profile-sub', scnName + ' · ' + filing + ' · ' + yr);
+        var chipEl = document.querySelector('.ws-profile');
+        if (chipEl) chipEl.title = 'Active household · ' + scnName + ' · ' + st;
         set('ws-hh', name);
         set('ws-profile-avatar', ini);
         set('ws-avatar', ini);
@@ -1103,8 +1125,17 @@
     // in the Net Worth / Investment Portfolio / Monthly Spending tiles;
     // an empty store keeps the illustrative sample. (Retirement Readiness
     // and the charts stay illustrative until a later slice.) ----
-    function money(n) { n = Number(n) || 0; var a = Math.abs(n); if (a >= 1e6) return '$' + (n / 1e6).toFixed(2) + 'M'; if (a >= 1e3) return '$' + Math.round(n / 1e3) + 'K'; return '$' + Math.round(n); }
+    function moneyC(n) { n = Number(n) || 0; var a = Math.abs(n); if (a >= 1e6) return '$' + (n / 1e6).toFixed(2) + 'M'; if (a >= 1e3) return '$' + Math.round(n / 1e3) + 'K'; return '$' + Math.round(n); }
     function full(n) { return '$' + Math.round(Number(n) || 0).toLocaleString('en-US'); }
+    // Honours Settings → preferences.currencyFormat ('full' shows exact
+    // dollars). Chart axes keep moneyC — full figures don't fit there.
+    function money(n) {
+      try {
+        var st = window.WealthSuite && window.WealthSuite.store;
+        if (st && st.get('preferences.currencyFormat') === 'full') return full(n);
+      } catch (e) {}
+      return moneyC(n);
+    }
     function escHtml(x) { return String(x == null ? '' : x).replace(/[&<>"]/g, function (c) { return ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[c]; }); }
     function metricEl(m) { return document.querySelector('[data-ws-metric="' + m + '"]'); }
     function refreshKPIs() {
@@ -1136,10 +1167,23 @@
         }, 0));
         var budget = ((s.expenses && s.expenses.categories) || []).reduce(function (t, c) { return t + (Number(c.budgetMonthly) || 0); }, 0);
 
+        applyAlertPrefs(s);
+
         var hasData = holdings.length > 0 || otherAssets > 0 || liab > 0 || portfolioVal > 0 || monthSpend > 0;
         var note = document.getElementById('ws-sample-note');
         if (!hasData) { if (note) { note.textContent = 'sample figures — connect accounts in the Data Hub'; note.style.color = 'var(--warn)'; } return; }
-        if (note) { note.textContent = 'live from your data'; note.style.color = 'var(--pos)'; }
+        if (note) {
+          // Stale-data alert (Settings): flag when the store hasn't been
+          // touched in preferences.alerts.staleDays (default 30).
+          var aPrefs = (s.preferences && s.preferences.alerts) || {};
+          var staleTxt = '';
+          if (aPrefs.staleData !== false && s.meta && s.meta.lastUpdated) {
+            var staleDays = Math.floor((Date.now() - new Date(s.meta.lastUpdated).getTime()) / 864e5);
+            if (staleDays >= (Number(aPrefs.staleDays) || 30)) staleTxt = ' · last updated ' + staleDays + ' days ago';
+          }
+          note.textContent = 'live from your data' + staleTxt;
+          note.style.color = staleTxt ? 'var(--warn)' : 'var(--pos)';
+        }
 
         var nw = metricEl('netWorth');
         if (nw) {
@@ -1216,7 +1260,7 @@
       for (var g = 0; g <= 3; g++) {
         var gv = maxV * g / 3, gy = Y(gv);
         grid += '<line x1="34" y1="' + gy.toFixed(1) + '" x2="648" y2="' + gy.toFixed(1) + '" style="stroke:var(--border);" stroke-width="1"></line>';
-        labels += '<text x="2" y="' + (gy - 4).toFixed(1) + '" font-size="14" style="fill:var(--text-3);" font-family="Roboto Mono,monospace">' + money(gv) + '</text>';
+        labels += '<text x="2" y="' + (gy - 4).toFixed(1) + '" font-size="14" style="fill:var(--text-3);" font-family="Roboto Mono,monospace">' + moneyC(gv) + '</text>';
       }
       var lastP = hist[hist.length - 1];
       var cx = X(hist.length - 1).toFixed(1), cy = Y(lastP.nw).toFixed(1);
@@ -1460,11 +1504,18 @@
     }
     function refreshAll() { refreshProfile(); refreshKPIs(); }
 
-    if (window.WealthSuite && window.WealthSuite.store) {
+    // suite-state.js is a defer script that runs after this inline one, so
+    // the store usually isn't attached yet — boot on DOMContentLoaded and
+    // subscribe there too (signature is (path, fn); '' = whole store).
+    function bootFromStore() {
       refreshAll();
-      try { window.WealthSuite.store.subscribe(refreshAll); } catch (e) {}
+      var st = window.WealthSuite && window.WealthSuite.store;
+      if (st) { try { st.subscribe('', refreshAll); } catch (e) {} }
+    }
+    if (window.WealthSuite && window.WealthSuite.store) {
+      bootFromStore();
     } else {
-      window.addEventListener('DOMContentLoaded', function () { setTimeout(refreshAll, 0); });
+      window.addEventListener('DOMContentLoaded', function () { setTimeout(bootFromStore, 0); });
     }
   })();
 </script>

--- a/monte_carlo.html
+++ b/monte_carlo.html
@@ -108,8 +108,8 @@ body{font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-serif;backgro
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6"><link rel="stylesheet" href="assets/theme.css?v=1">
 <script src="https://d3js.org/d3.v7.min.js"></script>
 <script src="assets/suite-state.js?v=8" defer></script>
-<script src="assets/suite.js?v=14" defer></script>
-<script src="assets/adapters/mc.js?v=1" defer></script>
+<script src="assets/suite.js?v=15" defer></script>
+<script src="assets/adapters/mc.js?v=2" defer></script>
 </head>
 <body>
 

--- a/net_worth.html
+++ b/net_worth.html
@@ -129,7 +129,7 @@ body{font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-serif;backgro
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6"><link rel="stylesheet" href="assets/theme.css?v=1">
 <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
 <script src="assets/suite-state.js?v=8" defer></script>
-<script src="assets/suite.js?v=14" defer></script>
+<script src="assets/suite.js?v=15" defer></script>
 <script src="assets/adapters/networth.js?v=1" defer></script>
 </head>
 <body>

--- a/portfolio_review.html
+++ b/portfolio_review.html
@@ -117,7 +117,7 @@ body{font-family:'Inter',sans-serif;background:var(--bg);color:var(--text);font-
 <link rel="stylesheet" href="assets/theme.css?v=1">
 <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
 <script src="assets/suite-state.js?v=8" defer></script>
-<script src="assets/suite.js?v=14" defer></script>
+<script src="assets/suite.js?v=15" defer></script>
 <script src="assets/adapters/portfolio.js?v=6" defer></script>
 </head>
 <body>

--- a/portfolio_tracker.html
+++ b/portfolio_tracker.html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="assets/tw-reskin.css?v=1">
     <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
     <script src="assets/suite-state.js?v=8" defer></script>
-    <script src="assets/suite.js?v=14" defer></script>
+    <script src="assets/suite.js?v=15" defer></script>
     <script src="assets/adapters/tracker.js?v=1" defer></script>
 </head>
 <body class="bg-gray-100 min-h-screen">

--- a/retirement_master_plan_2.html
+++ b/retirement_master_plan_2.html
@@ -161,7 +161,7 @@ body{font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-serif;backgro
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6"><link rel="stylesheet" href="assets/theme.css?v=1">
 <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
 <script src="assets/suite-state.js?v=8" defer></script>
-<script src="assets/suite.js?v=14" defer></script>
+<script src="assets/suite.js?v=15" defer></script>
 <script src="assets/adapters/retirement.js?v=6" defer></script>
 </head>
 <body>

--- a/roth_conversion.html
+++ b/roth_conversion.html
@@ -15,8 +15,8 @@
     <link rel="stylesheet" href="assets/tw-reskin.css?v=1">
     <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
     <script src="assets/suite-state.js?v=8" defer></script>
-    <script src="assets/suite.js?v=14" defer></script>
-    <script src="assets/adapters/roth.js?v=1" defer></script>
+    <script src="assets/suite.js?v=15" defer></script>
+    <script src="assets/adapters/roth.js?v=2" defer></script>
 </head>
 <body class="bg-gray-100 min-h-screen">
     <div id="root"></div>
@@ -121,6 +121,7 @@
           if (d.retireAge    != null) setRetireAge(String(d.retireAge));
           if (d.tradBalance  != null) setTradBalance(String(d.tradBalance));
           if (d.currentIncome != null) setCurrentIncome(String(d.currentIncome));
+          if (d.targetBracket != null && ['12','22','24','32'].indexOf(String(d.targetBracket)) !== -1) setTargetBracket(String(d.targetBracket));
         };
         return () => { delete window.__rothSeed; };
       }, []);

--- a/settings.html
+++ b/settings.html
@@ -268,7 +268,7 @@
 
 </div>
 
-<script src="assets/suite.js?v=14" defer></script>
+<script src="assets/suite.js?v=15" defer></script>
 <script src="assets/suite-state.js?v=8" defer></script>
 <script>
 (function () {

--- a/social_security.html
+++ b/social_security.html
@@ -115,7 +115,7 @@ input[type=range]::-moz-range-thumb{width:24px;height:24px;border-radius:50%;bac
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"><link rel="stylesheet" href="assets/suite.css?v=6"><link rel="stylesheet" href="assets/theme.css?v=1">
 <script>(function(){try{var p=localStorage.getItem('wealthSuite.themePreference');if(!['system','light','dark'].includes(p))p='system';var r=p==='system'?(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',r);document.documentElement.setAttribute('data-theme-pref',p);}catch(e){}})();</script>
 <script src="assets/suite-state.js?v=8" defer></script>
-<script src="assets/suite.js?v=14" defer></script>
+<script src="assets/suite.js?v=15" defer></script>
 <script src="assets/adapters/ss.js?v=1" defer></script>
 </head>
 <body>


### PR DESCRIPTION
Backlog item 1 — everything Settings writes is now read somewhere:

- **Active scenario** (`preferences.scenarios[]` / `activeScenarioId`): named in the dashboard profile chip and every tool's household banner; its `targetRetireAge` overrides the plan in the Roth and Monte Carlo adapters; its `withdrawalRate` overrides the MC withdrawal (rate% × starting balance).
- **`fedBracket`**: seeds the Roth planner's "fill through bracket" select, snapped to its 12/22/24/32 options. Asset & Cap-Gains deliberately untouched — it has no bracket input (computes marginal rates from income).
- **`currencyFormat`**: 'full' renders exact dollars in the dashboard KPIs/legends/stat tiles and in the shared household banner (new `WealthSuite.fmtMoney`); chart axes stay compact.
- **Alert prefs**: `quarterlyTax:false` hides the Q2 tax banner; `staleData`/`staleDays` turn the live-data note into "last updated N days ago".
- **Bug fix**: the dashboard registered its store subscription as `subscribe(fn)` against a `(path, fn)` API — and the boot path that actually runs never subscribed at all — so it never re-rendered on store changes. Fixed and verified live via cross-document storage event.

Cache busters: suite.js v14→v15 (all pages), roth.js v2, mc.js v2.

Verified headless (seeded store): scenario chip "Retire at 55 · MFJ · 2026", hidden tax banner, stale note at 68 days, $2,000,000 full-format KPIs, MC seeded 55 / $80,000, Roth bracket 24%, empty store keeps the sample state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCk2cZd8drTYGEsmnjZMQw