### PR TITLE
Estate Plan live figures from the store (Phase 13p)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -593,6 +593,29 @@ Phase 13o (Data Hub polish — backlog item 1):
   Chrome (`--virtual-time-budget`), synthetic DataTransfer drops, store
   assertions.
 
+Phase 13p (Estate Plan live figures — backlog item 1):
+- `estate_plan.html` only: hardcoded sample figures now compute from the
+  store, gated exactly like the dashboard (empty store keeps the sample;
+  subtitle flips to "live from your data"). `data-est="…"` hooks + an
+  inline script (no adapter file; page stays self-contained).
+- **Estate size mirrors the dashboard net-worth formula** (index.html
+  `refreshKPIs`): portfolio.totalValue (fallback per-share holdings sum)
+  + otherAssets + retirement.balances.total − liabilities. Gate:
+  any asset component > 0.
+- **WA estate tax**: graduated pre-2025 table on the excess over the $3M
+  exclusion (10/14/15/16/18/19/19.5/20% over 1/1/1/1/2/1/2M/∞ slices —
+  $500k excess ≈ $50k, matching the old sample). **Federal**: 40% over
+  $30M MFJ / $15M single (`household.filingStatus`); OBBBA card + header
+  + narrative note re-render (below vs ABOVE wording).
+- **WA-vs-NV table**: tier rows carry `data-tier-max`; the highlighted
+  "← you" row is repositioned under the matching tier and its label/
+  strategy/delta/recommendation cells re-render from per-tier templates
+  with the computed WA tax. ILIT "both spouses at 51" → live ages.
+- Verified via the verify-skill harness: empty store keeps sample;
+  $3.6M MFJ → ~$600k/~$60k under <$5M tier; $12M → ~$1.5M, 10–20M tier;
+  $18M single → fed ~$1.2M ABOVE wording + $15M header; persists across
+  reload.
+
 ## Constraints to preserve
 
 - **Zero build step.** No Vite/Webpack until scope demands it.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -4,13 +4,11 @@
 
 ## Up next (roughly by value)
 
-1. **Estate Plan live figures** — `estate_plan.html` is static analysis text; compute estate size / WA taxable excess / est. tax from Net Worth data in the store.
+1. **Site Map page** — sidebar "Review → Site Map" is a non-navigating "Soon" chip; build per `Site Map.dc.html` in the design handoff bundle.
 
-2. **Site Map page** — sidebar "Review → Site Map" is a non-navigating "Soon" chip; build per `Site Map.dc.html` in the design handoff bundle.
+2. **AI chat re-homing** — `assets/ai/chat.js` + `briefing.js` still exist but nothing loads them since the shell rebuild. Decide: chat panel inside the shell? Delete briefing?
 
-3. **AI chat re-homing** — `assets/ai/chat.js` + `briefing.js` still exist but nothing loads them since the shell rebuild. Decide: chat panel inside the shell? Delete briefing?
-
-4. **Retirement Master Plan hardcoded numbers** — the tool's banner/projections use hardcoded figures ($1.35M, age 45, $90k spend); its adapter seeds some, but a fuller store-driven pass is pending (handoff step 4 for tools).
+3. **Retirement Master Plan hardcoded numbers** — the tool's banner/projections use hardcoded figures ($1.35M, age 45, $90k spend); its adapter seeds some, but a fuller store-driven pass is pending (handoff step 4 for tools).
 
 ## Known issues / watchlist
 - **TaxAssetCalcv4 renders blank in *headless* Chrome** (Babel+D3 vs virtual-time). Fine in real browsers since the 7.29.7 pin. Don't chase it in headless tests.
@@ -24,6 +22,11 @@
 - Cloudflare Pages + Access privacy migration (see memory: quote-infra-and-privacy-plan)
 
 ## Done recently (context for resuming)
+- Phase 13p: Estate Plan live figures — `estate_plan.html` computes
+  estate size (dashboard net-worth formula), WA taxable excess + est.
+  tax (graduated 10–20% table over the $3M exclusion), federal tax vs
+  $30M MFJ / $15M single, repositions the "← you" tier row, live ILIT
+  ages. Gated: empty store keeps the illustrative sample.
 - Phase 13o: Data Hub polish — column-mapping editor in the import preview
   (Edit mapping: per-field column selects + lot-total checkbox, re-parses
   live), in-hub Refresh Prices (same worker→query2→query1 chain and

--- a/estate_plan.html
+++ b/estate_plan.html
@@ -171,12 +171,12 @@ body{font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-serif;backgro
 <div class="hdr">
   <div class="hdr-l">
     <h1>Estate Plan</h1>
-    <p>WA household &middot; community property &middot; extracted from the Retirement Master Plan</p>
+    <p data-est="subtitle">WA household &middot; community property &middot; extracted from the Retirement Master Plan</p>
   </div>
   <div class="hdr-r">
-    <div class="hs"><div class="hs-v">$30M</div><div class="hs-l">Fed exemption (MFJ)</div></div>
+    <div class="hs"><div class="hs-v" data-est="hdr-fedex">$30M</div><div class="hs-l" data-est="hdr-fedex-l">Fed exemption (MFJ)</div></div>
     <div class="hs"><div class="hs-v" style="color:#FCD34D">$3M</div><div class="hs-l">WA exclusion</div></div>
-    <div class="hs"><div class="hs-v" style="color:#FCA5A5">~$50k</div><div class="hs-l">Est. WA tax</div></div>
+    <div class="hs"><div class="hs-v" style="color:#FCA5A5" data-est="hdr-watax">~$50k</div><div class="hs-l">Est. WA tax</div></div>
   </div>
 </div>
 
@@ -186,11 +186,11 @@ body{font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-serif;backgro
     <div class="cs">The One Big Beautiful Bill Act permanently raised the federal estate/gift/GST exemption. No more sunset anxiety.</div>
     <div class="g4">
       <div class="sc"><div class="sc-l">Federal exemption (2026+)</div><div class="sc-v g">$15M</div></div>
-      <div class="sc"><div class="sc-l">MFJ combined (portability)</div><div class="sc-v g">$30M</div></div>
-      <div class="sc"><div class="sc-l">Your est. estate</div><div class="sc-v">$3.5M+</div></div>
-      <div class="sc"><div class="sc-l">Federal estate tax due</div><div class="sc-v g">$0</div></div>
+      <div class="sc"><div class="sc-l" data-est="fed-combined-l">MFJ combined (portability)</div><div class="sc-v g" data-est="fed-combined">$30M</div></div>
+      <div class="sc"><div class="sc-l">Your est. estate</div><div class="sc-v" data-est="estate-1">$3.5M+</div></div>
+      <div class="sc"><div class="sc-l">Federal estate tax due</div><div class="sc-v g" data-est="fedtax">$0</div></div>
     </div>
-    <div class="ib ib-g">At $3.5M, you are well below the $30M MFJ federal exemption. Federal estate tax is permanently a non-issue for your estate. However, the exemption is indexed to inflation from 2027 — file portability election on first spouse's death (IRS Form 706) to preserve the deceased spouse's unused exclusion. This is free insurance even when clearly under the limit.</div>
+    <div class="ib ib-g" data-est="fed-note">At $3.5M, you are well below the $30M MFJ federal exemption. Federal estate tax is permanently a non-issue for your estate. However, the exemption is indexed to inflation from 2027 — file portability election on first spouse's death (IRS Form 706) to preserve the deceased spouse's unused exclusion. This is free insurance even when clearly under the limit.</div>
   </div>
 
   <div class="card" style="border-color:var(--red)">
@@ -198,9 +198,9 @@ body{font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-serif;backgro
     <div class="cs">WA estate tax is separate from federal. New SB 6347 restores pre-2025 rates (top rate: 20%, down from 35%). $3M exclusion retained, NOT indexed for inflation.</div>
     <div class="g4">
       <div class="sc"><div class="sc-l">WA exclusion</div><div class="sc-v">$3.0M</div></div>
-      <div class="sc"><div class="sc-l">Your estate</div><div class="sc-v a">$3.5M+</div></div>
-      <div class="sc"><div class="sc-l">WA taxable excess</div><div class="sc-v a">~$0.5M</div></div>
-      <div class="sc"><div class="sc-l">Est. WA estate tax</div><div class="sc-v a">~$50k</div></div>
+      <div class="sc"><div class="sc-l">Your estate</div><div class="sc-v a" data-est="estate-2">$3.5M+</div></div>
+      <div class="sc"><div class="sc-l">WA taxable excess</div><div class="sc-v a" data-est="waexcess">~$0.5M</div></div>
+      <div class="sc"><div class="sc-l">Est. WA estate tax</div><div class="sc-v a" data-est="watax">~$50k</div></div>
     </div>
     <div class="ib ib-r">WA estate tax rates run 10–20% on the excess above $3M. The $3M exclusion does NOT adjust for inflation and WA does NOT allow portability between spouses — each spouse needs their own $3M exclusion via proper trust planning (A/B trust). Without an A/B trust, only one $3M exclusion is available. With proper planning: $6M combined exclusion means you pay little to no WA estate tax at $3.5M. But as your estate grows past $6M, this protection erodes.</div>
   </div>
@@ -229,42 +229,42 @@ body{font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-serif;backgro
         </tr>
       </thead>
       <tbody>
-        <tr>
+        <tr data-tier-max="5e6">
           <td>&lt;$5M</td>
           <td>A/B trust; protect WA $3M exclusion per spouse</td>
           <td>Not needed</td>
           <td style="font-weight:600;color:var(--green)">$0–$300k</td>
           <td>Keep it simple — focus on WA estate planning, not relocation</td>
         </tr>
-        <tr>
+        <tr data-tier-max="10e6">
           <td>$5M–$10M</td>
           <td>A/B trust + optimize taxes; annual gifting</td>
           <td>Selective trust</td>
           <td style="font-weight:600;color:var(--amber)">$300k–$1.2M</td>
           <td>Consider NV only if large liquidity event is coming or millionaire tax applies</td>
         </tr>
-        <tr style="background:var(--blue-bg)">
-          <td style="color:var(--blue-t)">$3.5M ← you</td>
-          <td style="color:var(--blue-t)">A/B trust + Roth conversions + DAF; WA estate tax ~$50k with proper trust; millionaire tax ~$0 if income managed below $1M</td>
-          <td style="color:var(--blue-t)">NV trust optional; mainly benefit if large liquidity events or estate growth expected</td>
-          <td style="font-weight:600;color:var(--blue-t)">$0–$300k</td>
-          <td style="color:var(--blue-t)"><strong>Focus on WA A/B trust — NV residency not needed at this estate size unless large capital events are planned</strong></td>
+        <tr style="background:var(--blue-bg)" id="est-you-row">
+          <td style="color:var(--blue-t)" data-est="you-label">$3.5M ← you</td>
+          <td style="color:var(--blue-t)" data-est="you-wa">A/B trust + Roth conversions + DAF; WA estate tax ~$50k with proper trust; millionaire tax ~$0 if income managed below $1M</td>
+          <td style="color:var(--blue-t)" data-est="you-nv">NV trust optional; mainly benefit if large liquidity events or estate growth expected</td>
+          <td style="font-weight:600;color:var(--blue-t)" data-est="you-delta">$0–$300k</td>
+          <td style="color:var(--blue-t)"><strong data-est="you-rec">Focus on WA A/B trust — NV residency not needed at this estate size unless large capital events are planned</strong></td>
         </tr>
-        <tr>
+        <tr data-tier-max="20e6">
           <td>$10M–$20M</td>
           <td>A/B + optimize; income + estate tax drag meaningful</td>
           <td>Trust + consider move</td>
           <td style="font-weight:600;color:var(--red)">$1.2M–$4M</td>
           <td>Start NV trust now; plan relocation before major gains events</td>
         </tr>
-        <tr>
+        <tr data-tier-max="40e6">
           <td>$20M–$40M</td>
           <td>Income + estate tax drag very high</td>
           <td>Trust + move</td>
           <td style="font-weight:600;color:var(--red)">$4M–$10M</td>
           <td>Execute NV trust immediately and plan a clean residency move</td>
         </tr>
-        <tr>
+        <tr data-tier-max="Infinity">
           <td>$40M+</td>
           <td>Very high compounding leakage across all WA taxes</td>
           <td>Core NV strategy</td>
@@ -289,7 +289,7 @@ body{font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-serif;backgro
     <div class="ri"><span class="bdg bdg-a">High value</span><span class="ri-t"><strong style="color:var(--text)">Donor-advised fund.</strong> Contribute appreciated stock → immediate federal deduction → reduces WA taxable estate → $100k deduction against WA millionaire tax. Fidelity Charitable, Schwab Charitable. "Bunching" strategy: contribute $200k in one year, take standard deduction the next — maximizes total deductions across years.</span></div>
     <div class="ri"><span class="bdg bdg-b">Long-term</span><span class="ri-t"><strong style="color:var(--text)">Roth IRA as legacy asset.</strong> Best possible asset for heirs: 10-year tax-free distribution. Under OBBBA's permanent $15M/$30M exemption, your estate passes federal-tax-free regardless — but Roth conversions still save heirs from income tax on inherited traditional IRAs. The heirs' savings is the real win.</span></div>
     <div class="ri"><span class="bdg bdg-p">NV strategy</span><span class="ri-t"><strong style="color:var(--text)">Nevada Incomplete Non-Grantor (NING) trust.</strong> Transfer assets to a NV trust — assets grow outside WA's taxing jurisdiction. WA's SB 6346 specifically adds back NING trust income, so this must be paired with genuine NV residency to be effective. Consult a multi-state trust attorney. If you establish NV residency, a NV dynasty trust can hold assets indefinitely with zero state estate, income, or capital gains tax.</span></div>
-    <div class="ri"><span class="bdg bdg-b">Consider</span><span class="ri-t"><strong style="color:var(--text)">Irrevocable life insurance trust (ILIT).</strong> Life insurance inside ILIT sits outside both federal and WA taxable estate. Death benefit funds the WA estate tax bill. Under OBBBA, federal ILIT need is reduced — but WA estate tax still applies, making ILIT valuable for WA residents. Get quotes now for both spouses at 51.</span></div>
+    <div class="ri"><span class="bdg bdg-b">Consider</span><span class="ri-t"><strong style="color:var(--text)">Irrevocable life insurance trust (ILIT).</strong> Life insurance inside ILIT sits outside both federal and WA taxable estate. Death benefit funds the WA estate tax bill. Under OBBBA, federal ILIT need is reduced — but WA estate tax still applies, making ILIT valuable for WA residents. Get quotes now for both spouses at <span data-est="ages">51</span>.</span></div>
   </div>
 
   <div class="card">
@@ -303,6 +303,140 @@ body{font-family:'Inter',-apple-system,'Helvetica Neue',Arial,sans-serif;backgro
     </div>
   </div>
 </div>
+
+<script>
+(function () {
+  'use strict';
+  // Live figures from the suite store. Empty store keeps the page's
+  // illustrative sample numbers (same gating convention as the dashboard).
+  var WA_EXCLUSION = 3e6;                        // SB 6347, not indexed
+  var FED_EXEMPTION = 15e6;                      // OBBBA, per person, 2026+
+  // WA graduated rates on the taxable excess above the exclusion
+  // (SB 6347 restores the pre-2025 table, top rate 20%).
+  var WA_BRACKETS = [
+    [1e6, 0.10], [1e6, 0.14], [1e6, 0.15], [1e6, 0.16],
+    [2e6, 0.18], [1e6, 0.19], [2e6, 0.195], [Infinity, 0.20],
+  ];
+  function waTax(excess) {
+    var tax = 0, left = Math.max(0, excess);
+    for (var i = 0; i < WA_BRACKETS.length && left > 0; i++) {
+      var slice = Math.min(left, WA_BRACKETS[i][0]);
+      tax += slice * WA_BRACKETS[i][1];
+      left -= slice;
+    }
+    return tax;
+  }
+  function fmtM(n) {
+    var a = Math.abs(n);
+    if (a >= 1e6) return '$' + (n / 1e6).toFixed(n >= 100e6 ? 0 : 1).replace(/\.0$/, '') + 'M';
+    if (a >= 1e3) return '$' + Math.round(n / 1e3) + 'k';
+    return '$' + Math.round(n);
+  }
+  function q(k) { return document.querySelector('[data-est="' + k + '"]'); }
+  function setText(k, t) { var el = q(k); if (el) el.textContent = t; }
+
+  function render(store) {
+    var s = store.export();
+    // Estate size mirrors the dashboard's net-worth formula
+    // (index.html refreshKPIs): portfolio + other assets + retirement
+    // balances − liabilities. holding.costBasis is PER-SHARE.
+    var holdings = (s.portfolio && s.portfolio.holdings) || [];
+    var portfolioVal = Number(s.portfolio && s.portfolio.totalValue) ||
+      holdings.reduce(function (t, h) { var per = Number(h.currentPrice) > 0 ? Number(h.currentPrice) : (Number(h.costBasis) || 0); return t + per * (Number(h.shares) || 0); }, 0);
+    var otherAssets = (s.otherAssets || []).reduce(function (t, a) { return t + (Number(a.value) || 0); }, 0);
+    var retire = Number(s.retirement && s.retirement.balances && s.retirement.balances.total) || 0;
+    var liabItems = (s.liabilities && s.liabilities.items) || [];
+    var liab = Number(s.liabilities && s.liabilities.total) || liabItems.reduce(function (t, l) { return t + (Number(l.balance) || 0); }, 0);
+    if (!(portfolioVal > 0 || otherAssets > 0 || retire > 0)) return;   // no data — keep the sample
+    var estate = Math.max(0, portfolioVal + otherAssets + retire - liab);
+
+    var mfj = !s.household || s.household.filingStatus !== 'single';
+    var fedEx = mfj ? FED_EXEMPTION * 2 : FED_EXEMPTION;
+    var fedExcess = Math.max(0, estate - fedEx);
+    var fedTax = fedExcess * 0.40;
+    var waExcess = Math.max(0, estate - WA_EXCLUSION);
+    var tax = waTax(waExcess);
+
+    // Header
+    setText('subtitle', 'WA household · community property · live from your data');
+    setText('hdr-fedex', fmtM(fedEx));
+    setText('hdr-fedex-l', 'Fed exemption (' + (mfj ? 'MFJ' : 'single') + ')');
+    setText('hdr-watax', tax > 0 ? '~' + fmtM(tax) : '$0');
+    var hdrTax = q('hdr-watax');
+    if (hdrTax) hdrTax.style.color = tax > 0 ? '#FCA5A5' : '#6EE7B7';
+
+    // OBBBA card
+    setText('fed-combined-l', mfj ? 'MFJ combined (portability)' : 'Single (no portability)');
+    setText('fed-combined', fmtM(fedEx));
+    setText('estate-1', fmtM(estate));
+    setText('fedtax', fedTax > 0 ? '~' + fmtM(fedTax) : '$0');
+    var ftEl = q('fedtax');
+    if (ftEl) ftEl.className = 'sc-v ' + (fedTax > 0 ? 'a' : 'g');
+    setText('fed-note', fedTax > 0
+      ? 'At ' + fmtM(estate) + ', you are ABOVE the ' + fmtM(fedEx) + (mfj ? ' MFJ' : '') + ' federal exemption — the ' + fmtM(fedExcess) + ' excess would face roughly ' + fmtM(fedTax) + ' of federal estate tax at 40%. Coordinate lifetime gifting and trust strategy with an estate attorney now.'
+      : 'At ' + fmtM(estate) + ', you are ' + (estate < fedEx * 0.5 ? 'well below' : 'below') + ' the ' + fmtM(fedEx) + (mfj ? ' MFJ' : '') + ' federal exemption. Federal estate tax is permanently a non-issue for your estate. However, the exemption is indexed to inflation from 2027 — file portability election on first spouse’s death (IRS Form 706) to preserve the deceased spouse’s unused exclusion. This is free insurance even when clearly under the limit.');
+
+    // WA card
+    setText('estate-2', fmtM(estate));
+    setText('waexcess', waExcess > 0 ? '~' + fmtM(waExcess) : '$0');
+    setText('watax', tax > 0 ? '~' + fmtM(tax) : '$0');
+    ['estate-2', 'waexcess', 'watax'].forEach(function (k) {
+      var el = q(k); if (el) el.className = 'sc-v ' + (waExcess > 0 ? 'a' : 'g');
+    });
+
+    // WA vs NV table — move the "you" row under the matching tier
+    var youRow = document.getElementById('est-you-row');
+    if (youRow) {
+      var TIERS = {
+        '5e6':  { wa: 'A/B trust + Roth conversions + DAF; WA estate tax ~{tax} with proper trust; millionaire tax ~$0 if income managed below $1M',
+                  nv: 'NV trust optional; mainly benefit if large liquidity events or estate growth expected',
+                  delta: '$0–$300k', rec: 'Focus on WA A/B trust — NV residency not needed at this estate size unless large capital events are planned' },
+        '10e6': { wa: 'A/B trust + annual gifting + DAF; WA estate tax ~{tax} even with trust planning',
+                  nv: 'Selective NV trust worth pricing out',
+                  delta: '$300k–$1.2M', rec: 'Consider NV if a large liquidity event is coming or the millionaire tax applies' },
+        '20e6': { wa: 'A/B trust + full optimization; WA estate tax ~{tax} plus income-tax drag is meaningful',
+                  nv: 'Trust + consider a residency move',
+                  delta: '$1.2M–$4M', rec: 'Start a NV trust now; plan relocation before major gains events' },
+        '40e6': { wa: 'Very high compounding leakage; WA estate tax ~{tax}',
+                  nv: 'Trust + move',
+                  delta: '$4M–$10M', rec: 'Execute NV trust immediately and plan a clean residency move' },
+        'Infinity': { wa: 'Very high compounding leakage across all WA taxes; WA estate tax ~{tax}',
+                  nv: 'Core NV strategy',
+                  delta: '$10M–$50M+', rec: 'Make NV your base — full trust + residency strategy is essential' },
+      };
+      var tierRows = Array.prototype.slice.call(document.querySelectorAll('tr[data-tier-max]'));
+      var host = null, key = 'Infinity';
+      for (var i = 0; i < tierRows.length; i++) {
+        var max = Number(tierRows[i].getAttribute('data-tier-max'));
+        if (estate < max) { host = tierRows[i]; key = tierRows[i].getAttribute('data-tier-max'); break; }
+      }
+      if (!host) host = tierRows[tierRows.length - 1];
+      host.parentNode.insertBefore(youRow, host.nextSibling);
+      var t = TIERS[key] || TIERS['Infinity'];
+      setText('you-label', fmtM(estate) + ' ← you');
+      setText('you-wa', t.wa.replace('{tax}', tax > 0 ? fmtM(tax) : '$0'));
+      setText('you-nv', t.nv);
+      setText('you-delta', t.delta);
+      setText('you-rec', t.rec);
+    }
+
+    // ILIT — spouse ages
+    var ages = ((s.household && s.household.spouses) || [])
+      .map(function (sp) { return Number(sp && sp.age); })
+      .filter(function (a) { return a > 0; });
+    if (ages.length) setText('ages', ages.join(' / '));
+  }
+
+  function init() {
+    var store = window.WealthSuite && window.WealthSuite.store;
+    if (!store) { setTimeout(init, 60); return; }
+    render(store);
+    store.subscribe('', function () { render(store); });
+  }
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
+  else init();
+})();
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
Completes backlog item 1 (Estate Plan live figures) — `estate_plan.html` only, plus docs.

## What's in it

The Estate Plan page's hardcoded sample figures now compute from the suite store, gated exactly like the dashboard: an empty store keeps the illustrative sample; with data, the subtitle flips to "live from your data" and the page re-renders on store changes.

- **Estate size** mirrors the dashboard net-worth formula (`index.html` `refreshKPIs`): `portfolio.totalValue` (per-share holdings-sum fallback) + other assets + retirement balances − liabilities.
- **WA estate tax** — graduated pre-2025 rate table (10 / 14 / 15 / 16 / 18 / 19 / 19.5 / 20%) on the excess over the $3M exclusion; header stat, card stats, and cell colors (amber ↔ green) all recompute.
- **Federal** — 40% over $30M MFJ / $15M single from `household.filingStatus`; the OBBBA card's combined-exemption cell, tax-due cell, and narrative note switch between "well below / below / ABOVE" variants.
- **WA-vs-NV matrix** — the highlighted "← you" row repositions under the matching wealth tier (`data-tier-max` on tier rows) and its label / strategy / delta / recommendation cells re-render from per-tier templates with the computed WA tax.
- **ILIT** — "both spouses at 51" becomes the household's live ages.

No adapter file — the page stays self-contained with `data-est` hooks + an inline script (static-content page, per the 13m extraction).

## Verified (headless harness, `.claude/skills/verify/SKILL.md` recipe)

- Empty store → sample untouched.
- $3.6M MFJ ($1.2M portfolio + $2.7M home − $300k mortgage) → ~$600k excess / ~$60k WA tax, you-row under <$5M, ages "51 / 49".
- $12M → ~$1.5M WA tax (bracket math verified by hand), you-row under $10M–$20M, fed $0.
- $18M single → header "$15M / Fed exemption (single)", fed tax ~$1.2M with ABOVE narrative, WA ~$2.7M.
- Fresh page load with persisted state renders the same figures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCk2cZd8drTYGEsmnjZMQw