### PR TITLE
Purchase dates + since-purchase Performance table (Phase 13r)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -652,6 +652,45 @@ Phase 13q (Retirement Master Plan live figures — backlog item 2):
   $709k matches the tool's own sample math), tiers $215k, buffer note
   $256k→$173k, MC paths 26 pts starting 7.28 at ages 65..90, rate 97%.
 
+Phase 13r (purchase dates + since-purchase Performance table):
+- **`holding.purchaseDate` added** (ISO 'YYYY-MM-DD', nullable —
+  additive, no schema bump). Captured in BOTH entry points:
+  - `data_hub.html` — CSV auto-map ('Purchase Date' / 'Date Acquired' /
+    'Acquisition Date' / 'Trade Date' / 'Open Date' headers), a
+    "Purchase date" select in the mapping editor, a Purchased column in
+    the preview (6-col grid now), and commit writes it (update rows only
+    overwrite when the CSV provides a date). `parseDate()` normalizes
+    MM/DD/YYYY / M/D/YY / ISO.
+  - `portfolio_tracker.html` — same header detection in `parseCSV`
+    (`parseDateISO`), import merge preserves an existing date when the
+    CSV lacks one, add-form "Purchased" date field, and an editable
+    Purchased date column in the holdings table.
+- **Dashboard Performance table (index.html) is now purchase-aware.**
+  Previously "Your Portfolio" was a hypothetical backtest: current
+  position weights × each ticker's full-period market return. Now it's a
+  **monthly chain-linked (time-weighted) return where each lot enters at
+  the first month boundary on/after its purchaseDate** — the buy-in
+  itself never counts as return; month returns are value-weighted
+  (shares × that month's adj-close); annualized over the ACTUAL span the
+  portfolio existed within the period; the $-growth column uses the
+  actual chained factor. Prices matched across tickers by 'YYYY-MM' key
+  (tolerates timestamp misalignment).
+- **Benchmarks are clipped to the same window per column**
+  (`growthFrom(series, windowStart)`), so each cell compares you vs the
+  index over the identical window — a 2-yr-old portfolio's "10Y" column
+  shows 2-yr annualized returns for BOTH rows. When your cell is absent
+  the benchmark falls back to the full period.
+- **No purchase dates = old behavior** (lots held for the whole period;
+  a short-history benchmark like VXUS still renders "—" beyond its
+  data). Subtitle switches between "since purchase …" and the old
+  "current holdings mix …" wording (the latter now hints to add dates).
+- Verified via the perfSeries test seam (synthetic VTI 8%/16y, ^GSPC
+  10%/16y, VXUS 5%/4y): purchase 24 mo ago → every column +8.0% you /
+  +10.0% S&P / +5.0% VXUS (same window); no dates → full-period with
+  VXUS "—" at 5Y/10Y/All. Hub paste (US + ISO dates) → preview + commit
+  → tracker mounts with populated date inputs → tracker CSV re-import
+  updates dates → store round-trip intact.
+
 ## Constraints to preserve
 
 - **Zero build step.** No Vite/Webpack until scope demands it.
@@ -760,7 +799,9 @@ info leaves the browser.
 **Holdings store:** `portfolio.holdings[]` array, each entry:
 ```js
 { ticker, name, shares, costBasis, currentPrice, priceUpdatedAt,
-  assetClass }  // assetClass: 'equity'|'bond'|'cash'|'other'
+  purchaseDate,  // ISO 'YYYY-MM-DD' or null (Phase 13r; feeds the
+                 // dashboard Performance table's since-purchase returns)
+  assetClass }   // assetClass: 'equity'|'bond'|'cash'|'other'
 ```
 
 **Dashboard panels:**

--- a/data_hub.html
+++ b/data_hub.html
@@ -89,7 +89,7 @@
     .dh-preview__head { padding: 11px 16px; background: var(--surface-2); display: flex; align-items: center; justify-content: space-between; gap: 10px; }
     .dh-preview__name { font-size: 12px; font-weight: 500; }
     .dh-ok { display: inline-flex; align-items: center; gap: 5px; font-size: 11px; color: var(--pos); font-weight: 500; }
-    .dh-prow { display: grid; grid-template-columns: 1fr .8fr 1fr 1.4fr 1fr; padding: 9px 16px; border-bottom: 1px solid var(--border); align-items: center; }
+    .dh-prow { display: grid; grid-template-columns: 1fr .8fr 1fr 1fr 1.2fr 1fr; padding: 9px 16px; border-bottom: 1px solid var(--border); align-items: center; }
     .dh-prow--head { padding: 8px 16px; background: var(--surface); }
     .dh-ph { font-size: 10px; color: var(--text-2); font-weight: 700; text-transform: uppercase; letter-spacing: .5px; }
     .dh-cell { font-size: 12px; color: var(--text-2); }
@@ -209,7 +209,7 @@
         <textarea class="dh-textarea" id="dh-paste-area" hidden placeholder="Ticker,Shares,Cost Basis,Account
 VTI,120,165.34,Fidelity Brokerage
 AAPL,50,142.80,Schwab 401(k)"></textarea>
-        <div class="dh-hint" style="line-height:1.5;">Accepted columns: Ticker, Shares, Cost Basis (per share; "…Total" headers auto-divide), Account, Date. Fidelity / Schwab / Vanguard headers auto-map; extra columns are ignored.</div>
+        <div class="dh-hint" style="line-height:1.5;">Accepted columns: Ticker, Shares, Cost Basis (per share; "…Total" headers auto-divide), Account, Purchase Date ("Acquisition Date" / "Date Acquired" / "Trade Date" auto-map — feeds the dashboard Performance table). Fidelity / Schwab / Vanguard headers auto-map; extra columns are ignored.</div>
       </div>
       <div class="dh-preview" id="dh-preview">
         <div class="dh-empty">Drop or paste a CSV to preview holdings before committing.</div>
@@ -524,20 +524,36 @@ AAPL,50,142.80,Schwab 401(k)"></textarea>
     }
     var parsed = [];
     var rawImport = null;   // { headers: [], rows: [[cells]] } — kept so mapping edits re-parse
-    var mapping = null;     // { tk, sh, cb, ac, costIsTotal, custom }
+    var mapping = null;     // { tk, sh, cb, ac, pd, costIsTotal, custom }
     var mapOpen = false;
+    // Purchase date → ISO 'YYYY-MM-DD'. Brokerages export MM/DD/YYYY (or
+    // M/D/YY); pass ISO through untouched. Returns null when unparseable.
+    function parseDate(s) {
+      s = String(s || '').trim();
+      if (!s) return null;
+      var iso = s.match(/^(\d{4})-(\d{2})-(\d{2})/);
+      if (iso) return iso[1] + '-' + iso[2] + '-' + iso[3];
+      var us = s.match(/^(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{2,4})$/);
+      if (us) {
+        var y = us[3].length === 2 ? (Number(us[3]) > 50 ? '19' + us[3] : '20' + us[3]) : us[3];
+        var mo = ('0' + us[1]).slice(-2), dy = ('0' + us[2]).slice(-2);
+        if (Number(mo) >= 1 && Number(mo) <= 12 && Number(dy) >= 1 && Number(dy) <= 31) return y + '-' + mo + '-' + dy;
+      }
+      return null;
+    }
     function detectMapping(headers) {
       var tk = findCol(headers, ['ticker', 'symbol']);
       var sh = findCol(headers, ['shares', 'quantity', 'qty']);
       var cb = findCol(headers, ['cost basis total', 'average cost basis', 'cost basis', 'cost_basis', 'cost']);
       var ac = findCol(headers, ['account']);
+      var pd = findCol(headers, ['purchase date', 'purchase_date', 'date acquired', 'acquisition date', 'acquired', 'trade date', 'open date']);
       // Fallback for 3-col generic (ticker,shares,cost_basis) with odd headers
       if (tk < 0 && headers.length >= 3) { tk = 0; sh = 1; cb = 2; }
       // Store convention (Portfolio Tracker): costBasis is PER-SHARE.
       // Vanguard-style "... total" headers carry lot totals → divide by
       // shares; "average"/generic cost headers are already per-share.
       var costIsTotal = cb >= 0 && headers[cb] != null && /total/i.test(headers[cb]);
-      return { tk: tk, sh: sh, cb: cb, ac: ac, costIsTotal: costIsTotal, custom: false };
+      return { tk: tk, sh: sh, cb: cb, ac: ac, pd: pd, costIsTotal: costIsTotal, custom: false };
     }
     function buildParsed() {
       if (!rawImport || !mapping || mapping.tk < 0) { parsed = []; return; }
@@ -553,7 +569,8 @@ AAPL,50,142.80,Schwab 401(k)"></textarea>
         var shares = mapping.sh >= 0 ? num(c[mapping.sh]) : 0;
         var rawCost = mapping.cb >= 0 ? num(c[mapping.cb]) : 0;
         var costPerShare = (mapping.costIsTotal && rawCost && shares) ? rawCost / shares : rawCost;
-        return { ticker: ticker, shares: shares, costBasis: costPerShare, account: account, status: status };
+        var purchaseDate = mapping.pd >= 0 ? parseDate(c[mapping.pd]) : null;
+        return { ticker: ticker, shares: shares, costBasis: costPerShare, account: account, purchaseDate: purchaseDate, status: status };
       }).filter(Boolean);
     }
     function mapSelect(field, label) {
@@ -574,16 +591,17 @@ AAPL,50,142.80,Schwab 401(k)"></textarea>
         ? '<span class="dh-ok">Custom mapping</span>'
         : '<span class="dh-ok"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="20 6 9 17 4 12"></polyline></svg>Columns mapped automatically</span>';
       var mapPanel = mapOpen
-        ? '<div class="dh-map">' + mapSelect('tk', 'Ticker') + mapSelect('sh', 'Shares') + mapSelect('cb', 'Cost basis') + mapSelect('ac', 'Account') +
+        ? '<div class="dh-map">' + mapSelect('tk', 'Ticker') + mapSelect('sh', 'Shares') + mapSelect('cb', 'Cost basis') + mapSelect('ac', 'Account') + mapSelect('pd', 'Purchase date') +
           '<label><input type="checkbox" id="dh-map-total"' + (mapping.costIsTotal ? ' checked' : '') + '> Cost column is a lot total (÷ shares)</label></div>'
         : '';
       var rowsHtml = parsed.length
-        ? '<div class="dh-prow dh-prow--head"><span class="dh-ph">Ticker</span><span class="dh-ph dh-cell--r">Shares</span><span class="dh-ph dh-cell--r">Cost Basis</span><span class="dh-ph" style="padding-left:12px;">Account</span><span class="dh-ph dh-cell--r">Status</span></div>' +
+        ? '<div class="dh-prow dh-prow--head"><span class="dh-ph">Ticker</span><span class="dh-ph dh-cell--r">Shares</span><span class="dh-ph dh-cell--r">Cost Basis</span><span class="dh-ph dh-cell--r">Purchased</span><span class="dh-ph" style="padding-left:12px;">Account</span><span class="dh-ph dh-cell--r">Status</span></div>' +
           shown.map(function (r) {
             var costTotal = (r.costBasis && r.shares) ? r.costBasis * r.shares : r.costBasis;
             return '<div class="dh-prow"><span class="dh-cell--tk">' + esc(r.ticker) + '</span>' +
               '<span class="dh-cell dh-cell--r dh-mono">' + (r.shares ? r.shares.toLocaleString('en-US') : '—') + '</span>' +
               '<span class="dh-cell dh-cell--r dh-mono">' + (costTotal ? fmtFull(costTotal) : '—') + '</span>' +
+              '<span class="dh-cell dh-cell--r dh-mono">' + (r.purchaseDate || '—') + '</span>' +
               '<span class="dh-cell" style="padding-left:12px;">' + (esc(r.account) || '—') + '</span>' +
               '<span class="dh-cell--r ' + stClass[r.status] + '">' + stLabel[r.status] + '</span></div>';
           }).join('') +
@@ -619,9 +637,12 @@ AAPL,50,142.80,Schwab 401(k)"></textarea>
       var hs = holdings();
       parsed.forEach(function (r) {
         var idx = hs.findIndex(function (h) { return h.ticker === r.ticker && (h.account || '') === (r.account || ''); });
-        if (idx >= 0) { hs[idx].shares = r.shares; hs[idx].costBasis = r.costBasis; }
+        if (idx >= 0) {
+          hs[idx].shares = r.shares; hs[idx].costBasis = r.costBasis;
+          if (r.purchaseDate) hs[idx].purchaseDate = r.purchaseDate;
+        }
         // `id` is required by the Portfolio Tracker (row edit/delete key on it)
-        else hs.push({ id: r.ticker + '-' + Date.now() + '-' + Math.random().toString(36).slice(2, 6), ticker: r.ticker, name: r.ticker, shares: r.shares, costBasis: r.costBasis, account: r.account, assetClass: 'equity', currentPrice: null, priceUpdatedAt: null });
+        else hs.push({ id: r.ticker + '-' + Date.now() + '-' + Math.random().toString(36).slice(2, 6), ticker: r.ticker, name: r.ticker, shares: r.shares, costBasis: r.costBasis, account: r.account, purchaseDate: r.purchaseDate || null, assetClass: 'equity', currentPrice: null, priceUpdatedAt: null });
       });
       store.set('portfolio.holdings', hs, EDIT);
       // record import + auto-register any unknown accounts referenced

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,6 +1,6 @@
 # Wealth Suite — Backlog
 
-*Updated 2026-07-09, after Phase 13q (Retirement Master Plan live figures — see CLAUDE.md Phase 13 log). This file is the resume point: pick the top unchecked item unless directed otherwise.*
+*Updated 2026-07-09, after Phase 13r (purchase dates + since-purchase Performance table — see CLAUDE.md Phase 13 log). This file is the resume point: pick the top unchecked item unless directed otherwise.*
 
 ## Up next (roughly by value)
 
@@ -10,6 +10,8 @@
 - **TaxAssetCalcv4 renders blank in *headless* Chrome** (Babel+D3 vs virtual-time). Fine in real browsers since the 7.29.7 pin. Don't chase it in headless tests.
 - **Babel pin**: every React page must use `@babel/standalone@7.29.7` (Babel 8 rejects raw `>` in JSX text → blank page).
 - `holding.costBasis` is **per-share** everywhere. Never write lot totals.
+- `holding.purchaseDate` is ISO `YYYY-MM-DD` or null. Null = "held forever"
+  in the dashboard Performance table (full-period return).
 - Net-worth history accrues one snapshot/day (`localStorage['wealthSuite.nwHistory']`) — the Growth chart needs ≥2 days of visits to draw.
 - Tracker doesn't live-subscribe to store changes while open (iframe remount covers the shell case).
 
@@ -19,6 +21,13 @@
 - Cloudflare Pages + Access privacy migration (see memory: quote-infra-and-privacy-plan)
 
 ## Done recently (context for resuming)
+- Phase 13r: purchase dates + since-purchase Performance table —
+  `holding.purchaseDate` captured in the Data Hub (CSV auto-map +
+  mapping editor + preview column) and Portfolio Tracker (CSV, add
+  form, editable table column); dashboard "Your Portfolio" row is now a
+  monthly chain-linked return where each lot enters at its purchase
+  date, benchmarks clipped to the same window per column; no dates =
+  old full-period behavior.
 - Phase 13q: Retirement Master Plan live figures — adapter v7 seeds the
   remaining hardcoded copy from the store (subtitle/title, 25×-spend
   target stat + tile, buffer tiers + inflation schedule + SS note,

--- a/index.html
+++ b/index.html
@@ -1043,13 +1043,28 @@
       var ann = Math.pow(last / start, 1 / spanYrs) - 1;
       return { ann: ann, factor: Math.pow(1 + ann, years) };
     }
+    // Growth anchored at an explicit start timestamp (used to clip a
+    // benchmark to the same window as the portfolio's purchase-dated
+    // return, so each column compares like-for-like).
+    function growthFrom(series, startTs) {
+      if (!series) return null;
+      var YEAR = 365.25 * 86400000;
+      var idx = -1;
+      for (var i = 0; i < series.ts.length; i++) { if (series.ts[i] <= startTs + 45 * 86400000) idx = i; else break; }
+      if (idx < 0) return null;
+      var start = series.px[idx], last = series.px[series.px.length - 1];
+      var spanYrs = (series.ts[series.ts.length - 1] - series.ts[idx]) / YEAR;
+      if (!(start > 0) || !(spanYrs > 0.1)) return null;
+      var ann = Math.pow(last / start, 1 / spanYrs) - 1;
+      return { ann: ann, factor: last / start };
+    }
     var perfBusy = false, perfLive = false;
     async function refreshPerformance(holdings, basis) {
       if (perfBusy || perfLive || !holdings.length || !(basis > 0)) return;
       perfBusy = true;
       try {
         function hv(h) { var per = Number(h.currentPrice) > 0 ? Number(h.currentPrice) : (Number(h.costBasis) || 0); return per * (Number(h.shares) || 0); }
-        // top 8 tickers by current value (weights renormalized per period)
+        // top 8 tickers by current value (bounds the quote fetches)
         var byTicker = {};
         holdings.forEach(function (h) { if (h.ticker) byTicker[h.ticker] = (byTicker[h.ticker] || 0) + hv(h); });
         var top = Object.keys(byTicker).sort(function (a, b) { return byTicker[b] - byTicker[a]; }).slice(0, 8)
@@ -1059,24 +1074,84 @@
         var series = {};
         await Promise.all(all.map(function (t) { return fetchSeries(t).then(function (s) { series[t] = s; }); }));
         if (!PERF_BENCH.some(function (b) { return series[b.t]; }) && !top.some(function (t) { return series[t]; })) return; // total outage → keep sample
-        var youCells = PERF_PERIODS.map(function (p) {
-          var usable = top.filter(function (t) { return growthFor(series[t], p.years) != null; });
-          if (!usable.length) return null;
-          var wTot = usable.reduce(function (s2, t) { return s2 + byTicker[t]; }, 0);
-          var factor = usable.reduce(function (s2, t) { return s2 + (byTicker[t] / wTot) * growthFor(series[t], p.years).factor; }, 0);
-          return { ann: Math.pow(factor, 1 / p.years) - 1, factor: factor };
+
+        // Per-lot view: each holding contributes only from its purchaseDate
+        // (no date = held for the whole period — the pre-purchase-date
+        // behavior). Shares are today's counts; a lot enters the chain at
+        // the first month boundary on/after its purchase date.
+        var lots = holdings.filter(function (h) { return h.ticker && top.indexOf(h.ticker) >= 0 && Number(h.shares) > 0; })
+          .map(function (h) {
+            var pd = null;
+            if (h.purchaseDate) { var d = new Date(String(h.purchaseDate).slice(0, 10) + 'T00:00:00'); if (!isNaN(d)) pd = d.getTime(); }
+            return { t: h.ticker, sh: Number(h.shares), pd: pd };
+          });
+        var anyDates = lots.some(function (l) { return l.pd != null; });
+        // month-keyed price maps ('YYYY-MM' → adj close) tolerate small
+        // timestamp misalignment between tickers
+        function monthKey(ts) { return new Date(ts).toISOString().slice(0, 7); }
+        var pxMap = {};
+        top.forEach(function (t) {
+          var s = series[t]; if (!s) return;
+          var m = {};
+          for (var i = 0; i < s.ts.length; i++) m[monthKey(s.ts[i])] = s.px[i];
+          pxMap[t] = m;
         });
+        var YEAR = 365.25 * 86400000;
+        // Chain-linked monthly time-weighted return for one period. A lot
+        // purchased mid-period enters at the next month boundary, so the
+        // buy-in itself never counts as return. Annualized over the ACTUAL
+        // span the portfolio existed within the period.
+        function twrCell(p) {
+          var periodStart = Date.now() - p.years * YEAR;
+          var bounds = {};
+          top.forEach(function (t) {
+            var s = series[t]; if (!s) return;
+            s.ts.forEach(function (ts) { if (ts >= periodStart - 45 * 86400000) bounds[monthKey(ts)] = ts; });
+          });
+          var keys = Object.keys(bounds).sort();
+          if (keys.length < 2) return null;
+          var factor = 1, firstTs = null, lastTs = null;
+          for (var i = 0; i < keys.length - 1; i++) {
+            var k0 = keys[i], k1 = keys[i + 1], t0 = bounds[k0];
+            var wSum = 0, gain = 0;
+            lots.forEach(function (l) {
+              var m = pxMap[l.t];
+              if (!m || m[k0] == null || m[k1] == null) return;
+              if (l.pd != null && l.pd > t0) return; // not yet purchased
+              var v0 = l.sh * m[k0];
+              wSum += v0;
+              gain += v0 * (m[k1] / m[k0] - 1);
+            });
+            if (wSum > 0) {
+              factor *= 1 + gain / wSum;
+              if (firstTs == null) firstTs = t0;
+              lastTs = bounds[k1];
+            }
+          }
+          if (firstTs == null) return null;
+          var span = (lastTs - firstTs) / YEAR;
+          if (span < 0.1) return null;
+          return { ann: Math.pow(factor, 1 / span) - 1, factor: factor, windowStart: firstTs };
+        }
+        var youCells = PERF_PERIODS.map(twrCell);
         if (!youCells.some(Boolean)) return;
         var rows = [{ name: 'Your Portfolio', color: 'var(--primary)', you: true, cells: youCells }];
         PERF_BENCH.forEach(function (b) {
           rows.push({
             name: b.name, color: b.color, you: false,
-            cells: PERF_PERIODS.map(function (p) { return growthFor(series[b.t], p.years); })
+            // benchmark over the SAME window as your portfolio's cell
+            // (purchase-clipped); full period when your cell is absent
+            cells: PERF_PERIODS.map(function (p, ci) {
+              var you = youCells[ci];
+              return you ? growthFrom(series[b.t], you.windowStart) : growthFor(series[b.t], p.years);
+            })
           });
         });
         renderPerfTable(rows, basis);
         var note = document.querySelector('[data-ws-metric="performance"] .ws-cardsub');
-        if (note) note.innerHTML = 'Annualized return of your current holdings mix vs benchmarks · on <span id="ws-perf-basis">' + fmtMoney(basis) + '</span> invested · dividends included';
+        if (note) note.innerHTML = (anyDates
+          ? 'Annualized return since purchase — holdings enter at their purchase date, benchmarks over the same window · on <span id="ws-perf-basis">' + fmtMoney(basis) + '</span> invested · dividends included'
+          : 'Annualized return of your current holdings mix vs benchmarks · on <span id="ws-perf-basis">' + fmtMoney(basis) + '</span> invested · dividends included · add purchase dates in the Data Hub or Tracker for since-purchase returns');
         perfLive = true;
       } catch (e) { /* keep sample */ }
       finally { perfBusy = false; }

--- a/portfolio_tracker.html
+++ b/portfolio_tracker.html
@@ -110,6 +110,22 @@
       return Number.isFinite(n) && n !== 0 ? n : null;
     }
 
+    // Purchase date → ISO 'YYYY-MM-DD' (brokerages export MM/DD/YYYY or
+    // M/D/YY; ISO passes through). Null when unparseable/absent.
+    function parseDateISO(s) {
+      s = String(s || '').trim();
+      if (!s) return null;
+      const iso = s.match(/^(\d{4})-(\d{2})-(\d{2})/);
+      if (iso) return `${iso[1]}-${iso[2]}-${iso[3]}`;
+      const us = s.match(/^(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{2,4})$/);
+      if (us) {
+        const y = us[3].length === 2 ? (Number(us[3]) > 50 ? '19' + us[3] : '20' + us[3]) : us[3];
+        const mo = ('0' + us[1]).slice(-2), dy = ('0' + us[2]).slice(-2);
+        if (Number(mo) >= 1 && Number(mo) <= 12 && Number(dy) >= 1 && Number(dy) <= 31) return `${y}-${mo}-${dy}`;
+      }
+      return null;
+    }
+
     function parseCSV(text) {
       const lines = text.split('\n').map(l => l.trim()).filter(Boolean);
       // Skip leading non-data lines (Fidelity/Schwab add a preamble)
@@ -143,6 +159,7 @@
 
       if (tickerCol < 0 || sharesCol < 0)
         throw new Error(`Could not find ticker/shares columns (detected: ${fmt}). Headers: ${headers.slice(0,6).join(', ')}`);
+      const dateCol = col('purchase date', 'purchase_date', 'date acquired', 'acquisition date', 'acquired', 'trade date', 'open date');
 
       const results = [];
       for (let i = headerIdx + 1; i < lines.length; i++) {
@@ -160,6 +177,7 @@
           id: `${ticker}-${Date.now()}-${i}`,
           ticker, name: ticker, shares,
           costBasis: costPerShare,
+          purchaseDate: dateCol >= 0 ? parseDateISO(cells[dateCol]) : null,
           currentPrice: priceFromValue,
           prevClose: null, dayChange: null, dayChangePct: null,
           priceUpdatedAt: priceFromValue ? Date.now() : null,
@@ -178,7 +196,7 @@
       const [activeTab,   setActiveTab]   = React.useState('holdings');
       const [growthRates, setGrowthRates] = React.useState(DEFAULT_RATES);
       const [importMsg,   setImportMsg]   = React.useState('');
-      const [addForm,     setAddForm]     = React.useState({ ticker: '', shares: '', costBasis: '', assetClass: 'equity' });
+      const [addForm,     setAddForm]     = React.useState({ ticker: '', shares: '', costBasis: '', purchaseDate: '', assetClass: 'equity' });
 
       const donutRef = React.useRef(null);
       const projRef  = React.useRef(null);
@@ -274,13 +292,14 @@
           id: `${ticker}-${Date.now()}`,
           ticker, name: ticker, shares,
           costBasis:      Number(addForm.costBasis) || null,
+          purchaseDate:   addForm.purchaseDate || null,
           currentPrice:   null, prevClose: null,
           dayChange: null, dayChangePct: null,
           priceUpdatedAt: null,
           assetClass:     addForm.assetClass,
         };
         setHoldings(prev => [...prev, newH]);
-        setAddForm({ ticker: '', shares: '', costBasis: '', assetClass: 'equity' });
+        setAddForm({ ticker: '', shares: '', costBasis: '', purchaseDate: '', assetClass: 'equity' });
         // Try fetching price immediately
         setPxStatus(s => ({ ...s, [ticker]: 'loading' }));
         try {
@@ -317,6 +336,7 @@
                 const idx = merged.findIndex(h => h.ticker === p.ticker);
                 if (idx >= 0) {
                   merged[idx] = { ...merged[idx], shares: p.shares, costBasis: p.costBasis ?? merged[idx].costBasis,
+                    purchaseDate: p.purchaseDate ?? merged[idx].purchaseDate,
                     currentPrice: p.currentPrice ?? merged[idx].currentPrice };
                 } else {
                   merged.push(p);
@@ -460,7 +480,7 @@
                   <table className="min-w-full text-sm">
                     <thead className="bg-gray-50">
                       <tr className="text-xs text-gray-400 uppercase">
-                        {['Ticker','Shares','Cost/Share','Price','Day $','Day %','Mkt Value','Total Cost','Gain/Loss','Class',''].map(h => (
+                        {['Ticker','Shares','Cost/Share','Purchased','Price','Day $','Day %','Mkt Value','Total Cost','Gain/Loss','Class',''].map(h => (
                           <th key={h} className="px-3 py-3 text-left font-medium whitespace-nowrap">{h}</th>
                         ))}
                       </tr>
@@ -488,6 +508,11 @@
                               <input type="number" value={h.costBasis ?? ''} min="0" step="0.01" placeholder="—"
                                 onChange={e => updateHolding(h.id, 'costBasis', e.target.value ? Number(e.target.value) : null)}
                                 className="w-24 border border-gray-200 rounded px-2 py-0.5 text-sm" />
+                            </td>
+                            <td className="px-3 py-2">
+                              <input type="date" value={h.purchaseDate ?? ''}
+                                onChange={e => updateHolding(h.id, 'purchaseDate', e.target.value || null)}
+                                className="w-32 border border-gray-200 rounded px-2 py-0.5 text-sm" />
                             </td>
                             <td className="px-3 py-2 whitespace-nowrap">
                               {h.currentPrice ? fmt2(h.currentPrice) : (
@@ -553,6 +578,12 @@
                     <input type="number" value={addForm.costBasis} placeholder="150.00" min="0" step="0.01"
                       onChange={e => setAddForm(f => ({ ...f, costBasis: e.target.value }))}
                       className="w-28 border border-gray-300 rounded px-2 py-1.5 text-sm" />
+                  </div>
+                  <div>
+                    <label className="block text-xs text-gray-500 mb-1">Purchased</label>
+                    <input type="date" value={addForm.purchaseDate}
+                      onChange={e => setAddForm(f => ({ ...f, purchaseDate: e.target.value }))}
+                      className="w-36 border border-gray-300 rounded px-2 py-1.5 text-sm" />
                   </div>
                   <div>
                     <label className="block text-xs text-gray-500 mb-1">Class</label>


### PR DESCRIPTION
Captures `holding.purchaseDate` at both data-entry points and makes the dashboard Performance table compute returns anchored to when holdings were actually bought.

## Before
"Your Portfolio" was a hypothetical backtest: current position weights × each ticker's full-period market return over 1Y/3Y/5Y/10Y/All. Purchase timing played no role, and no purchase date was captured anywhere.

## Capture
- **Data Hub**: CSV auto-maps `Purchase Date` / `Date Acquired` / `Acquisition Date` / `Trade Date` / `Open Date` headers; "Purchase date" select in the mapping editor; Purchased column in the preview; commit writes it (updates only overwrite when the CSV provides a date). MM/DD/YYYY, M/D/YY, and ISO all normalize to `YYYY-MM-DD`.
- **Portfolio Tracker**: same header detection in its CSV parser, a "Purchased" date field on the add form, and an editable date column in the holdings table. Import merge preserves an existing date when the CSV lacks one.

## Performance table
- "Your Portfolio" is now a **monthly chain-linked time-weighted return**: each lot enters at the first month boundary on/after its purchase date, so the buy-in itself never counts as return; month returns are value-weighted; annualized over the actual span held within each period.
- **Benchmarks are clipped to the same window per column** — a 2-year-old portfolio's "10Y" cell compares 2-year annualized returns for both rows (like-for-like).
- **Holdings without dates keep today's full-period behavior** (including "—" for benchmarks whose history doesn't reach). The subtitle states which mode is active and hints where to add dates.

## Verification (headless harness, perfSeries test seam)
- Synthetic VTI 8%/16y, ^GSPC 10%/16y, VXUS 5%/4y; VTI purchased 24 months ago → every column reads +8.0% you / +10.0% S&P / +5.0% Intl over the shared 2-year window; without dates → full-period figures with VXUS "—" at 5Y/10Y/All.
- Hub paste with US-format and ISO dates → preview + commit → tracker mounts with populated date inputs → tracker CSV re-import updates dates → store round-trip intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XCGeYGJDd37BwJAZJcoSW