### PR TITLE
Dashboard shell UI cleanup (Phase 13s)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -691,6 +691,21 @@ Phase 13r (purchase dates + since-purchase Performance table):
   → tracker mounts with populated date inputs → tracker CSV re-import
   updates dates → store round-trip intact.
 
+Phase 13s (dashboard shell UI cleanup — per user screenshot):
+- index.html only. Removed from the topbar: the "← Dashboard" back
+  chip + "New tab" chip (tool navigation is the sidebar now — the
+  router's showTool/showDashboard no longer toggle them), the theme
+  cycle button (theme is set in Settings → Appearance; the shell still
+  APPLIES the preference — `applyTheme` kept, along with the mql and
+  cross-document `storage` listeners), and the "Import Data" button
+  (duplicated the Data Hub promo). Removed from the sidebar: the whole
+  REVIEW section (its only item was the deferred Site Map "Soon" chip).
+- Dead CSS pruned (.ws-back/.ws-newtab/.ws-themebtn/.ws-importbtn/
+  .is-soon/.ws-badge--soon); `.ws-badge`/`--q2` kept (Tax Plan chip).
+- Verified headless: elements gone, hamburger/bell/profile/Data Hub/
+  Settings intact, theme still applied from the stored preference,
+  sidebar→tool→Dashboard routing works, KPI sample renders.
+
 ## Constraints to preserve
 
 - **Zero build step.** No Vite/Webpack until scope demands it.

--- a/index.html
+++ b/index.html
@@ -88,11 +88,8 @@
     .ws-navitem svg { flex-shrink: 0; }
     .ws-navitem:hover { background: var(--surface-2); color: var(--text); }
     .ws-navitem.is-active { background: var(--primary-weak); color: var(--primary-text); }
-    .ws-navitem.is-soon { opacity: .5; cursor: default; }
-    .ws-navitem.is-soon:hover { background: transparent; color: var(--text-2); }
     .ws-badge { margin-left: auto; padding: 2px 7px; border-radius: 20px; font-size: 9px; font-weight: 700; }
     .ws-badge--q2 { background: var(--warn-weak); color: var(--warn); }
-    .ws-badge--soon { background: var(--surface-2); color: var(--text-3); }
 
     .ws-sidefoot { padding: 12px; border-top: 1px solid var(--border); flex-shrink: 0; display: flex; flex-direction: column; gap: 8px; }
     .ws-datahub { padding: 12px 14px; background: var(--primary-weak); border-radius: 12px; cursor: default; display: block; text-decoration: none; }
@@ -111,10 +108,6 @@
     .ws-sep { color: var(--text-3); font-size: 16px; }
     .ws-date { font-size: 12.5px; color: var(--text-2); font-family: 'Roboto Mono', monospace; }
     .ws-topbar__spacer { flex: 1; }
-    .ws-themebtn { display: flex; align-items: center; gap: 7px; padding: 8px 14px; background: var(--surface-2); border: 1px solid var(--border); border-radius: 24px; color: var(--text-2); font-size: 12px; font-weight: 500; cursor: pointer; font-family: inherit; user-select: none; }
-    .ws-themebtn:hover { color: var(--text); border-color: var(--primary); }
-    .ws-importbtn { display: flex; align-items: center; gap: 7px; padding: 9px 16px; background: var(--primary-weak); border: none; border-radius: 24px; color: var(--primary-text); font-size: 12.5px; font-weight: 500; cursor: pointer; font-family: inherit; text-decoration: none; }
-    .ws-importbtn:hover { filter: brightness(0.96); }
     .ws-bell { width: 40px; height: 40px; border-radius: 50%; background: var(--surface-2); display: flex; align-items: center; justify-content: center; cursor: pointer; position: relative; }
     .ws-bell__dot { position: absolute; top: 9px; right: 9px; width: 7px; height: 7px; background: var(--warn); border-radius: 50%; border: 2px solid var(--surface); }
     .ws-profile { display: flex; align-items: center; gap: 9px; padding: 5px 12px 5px 6px; background: var(--surface-2); border: 1px solid var(--border); border-radius: 24px; cursor: default; }
@@ -124,10 +117,6 @@
 
     /* ---- Top-bar nav cluster (back / title / new-tab) ---- */
     .ws-topbar__nav { display: flex; align-items: center; gap: 10px; }
-    .ws-back { display: inline-flex; align-items: center; gap: 6px; padding: 7px 13px; border-radius: 24px; cursor: pointer; color: var(--text-2); font-size: 12.5px; font-weight: 500; border: 1px solid var(--border); background: none; font-family: inherit; }
-    .ws-back:hover { color: var(--text); border-color: var(--primary); }
-    .ws-newtab { display: inline-flex; align-items: center; gap: 5px; padding: 6px 12px; border-radius: 20px; background: var(--surface-2); border: 1px solid var(--border); font-size: 11px; color: var(--text-2); text-decoration: none; }
-    .ws-newtab:hover { color: var(--text); border-color: var(--primary); }
 
     /* ---- Scrollable content + embedded tool frame ---- */
     .ws-content { flex: 1; display: flex; flex-direction: column; overflow-y: auto; padding: 24px 28px 40px; animation: ws-fade .4s ease; }
@@ -248,7 +237,7 @@
       .ws-backdrop { display: block; position: fixed; inset: 0; background: rgba(0,0,0,.45); z-index: 35; opacity: 0; visibility: hidden; transition: opacity .25s ease; }
       .ws-shell.is-mobnav-open .ws-backdrop { opacity: 1; visibility: visible; }
     }
-    @media (max-width: 620px) { .ws-kpis { grid-template-columns: 1fr; } .ws-content { padding: 20px 16px 40px; } .ws-importbtn, .ws-profile .sb-x { display: none; } }
+    @media (max-width: 620px) { .ws-kpis { grid-template-columns: 1fr; } .ws-content { padding: 20px 16px 40px; } .ws-profile .sb-x { display: none; } }
   </style>
 </head>
 <body class="suite-body">
@@ -333,12 +322,6 @@
         <span class="sb-x">Monte Carlo</span>
       </a>
 
-      <div class="ws-navlabel sb-x">Review</div>
-      <span class="ws-navitem is-soon" title="Site Map — coming soon">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><polygon points="1 6 1 22 8 18 16 22 23 18 23 2 16 6 8 2 1 6"></polygon><line x1="8" y1="2" x2="8" y2="18"></line><line x1="16" y1="6" x2="16" y2="22"></line></svg>
-        <span class="sb-x">Site Map</span>
-        <span class="ws-badge ws-badge--soon sb-x">Soon</span>
-      </span>
     </nav>
 
     <div class="ws-sidefoot">
@@ -367,29 +350,11 @@
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
       </button>
       <div class="ws-topbar__nav">
-        <button class="ws-back" id="ws-back" type="button" hidden title="Back to Dashboard">
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="19" y1="12" x2="5" y2="12"></line><polyline points="12 19 5 12 12 5"></polyline></svg>
-          Dashboard
-        </button>
         <span class="ws-pagetitle" id="ws-title">Dashboard</span>
         <span class="ws-sep" id="ws-datesep">·</span>
         <span class="ws-date" id="ws-date">—</span>
-        <a class="ws-newtab" id="ws-newtab" hidden target="_blank" rel="noopener" title="Open in a new tab">
-          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
-          New tab
-        </a>
       </div>
       <div class="ws-topbar__spacer"></div>
-
-      <button class="ws-themebtn" id="ws-theme" type="button" title="Cycle theme: system → light → dark">
-        <span id="ws-theme-icon" aria-hidden="true"></span>
-        <span id="ws-theme-label">Theme</span>
-      </button>
-
-      <a class="ws-importbtn" href="data_hub.html" title="Import data in the Data Hub">
-        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3"></path></svg>
-        Import Data
-      </a>
 
       <div class="ws-bell" title="Notifications">
         <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="var(--text-2)" stroke-width="2" stroke-linecap="round"><path d="M18 8A6 6 0 006 8c0 7-3 9-3 9h18s-3-2-3-9"></path><path d="M13.73 21a2 2 0 01-3.46 0"></path></svg>
@@ -755,9 +720,7 @@
     var dashView = document.getElementById('ws-dash-view');
     var content = document.getElementById('ws-content');
     var titleEl = document.getElementById('ws-title');
-    var backEl = document.getElementById('ws-back');
     var dateSep = document.getElementById('ws-datesep');
-    var newtabEl = document.getElementById('ws-newtab');
     var navItems = Array.prototype.slice.call(document.querySelectorAll('.ws-navitem[href]'));
 
     function fileFromHref(href) {
@@ -795,8 +758,6 @@
       if (frame) { frame.hidden = true; frame.removeAttribute('src'); }
       if (dashView) dashView.hidden = false;
       if (content) content.classList.remove('is-tool');
-      if (backEl) backEl.hidden = true;
-      if (newtabEl) newtabEl.hidden = true;
       if (dateSep) dateSep.hidden = false;
       var d = document.getElementById('ws-date'); if (d) d.hidden = false;
       if (titleEl) titleEl.textContent = 'Dashboard';
@@ -809,10 +770,8 @@
       if (dashView) dashView.hidden = true;
       if (content) content.classList.add('is-tool');
       if (frame) { if (frame.getAttribute('src') !== routeKey) frame.setAttribute('src', routeKey); frame.hidden = false; frame.setAttribute('title', title); }
-      if (backEl) backEl.hidden = false;
       if (dateSep) dateSep.hidden = true;
       var d = document.getElementById('ws-date'); if (d) d.hidden = true;
-      if (newtabEl) { newtabEl.hidden = false; newtabEl.setAttribute('href', routeKey); }
       if (titleEl) titleEl.textContent = title;
       document.title = 'Wealth Suite — ' + title;
       setActive(routeKey);
@@ -836,38 +795,23 @@
       if (r === 'index.html') { e.preventDefault(); navigate(''); }
       else if (ROUTES[r]) { e.preventDefault(); navigate(r); }
     });
-    if (backEl) backEl.addEventListener('click', function () { navigate(''); });
     route();
 
     // ---- Theme cycle (system → light → dark), shared preference key ----
     var TKEY = 'wealthSuite.themePreference';
     var ORDER = ['system', 'light', 'dark'];
     var mql = window.matchMedia('(prefers-color-scheme: dark)');
-    var ICONS = {
-      system: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"></rect><line x1="8" y1="21" x2="16" y2="21"></line><line x1="12" y1="17" x2="12" y2="21"></line></svg>',
-      light:  '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"></path></svg>',
-      dark:   '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"></path></svg>'
-    };
-    var LABELS = { system: 'System', light: 'Light', dark: 'Dark' };
     function readPref() { var v = localStorage.getItem(TKEY); return ORDER.indexOf(v) >= 0 ? v : 'system'; }
     function resolve(p) { return p === 'system' ? (mql.matches ? 'dark' : 'light') : p; }
-    var iconEl = document.getElementById('ws-theme-icon');
-    var labelEl = document.getElementById('ws-theme-label');
+    // Theme is set in Settings → Appearance; the shell only applies it
+    // (topbar cycle button removed in the Phase 13s cleanup).
     function applyTheme() {
       var p = readPref();
       var resolved = resolve(p);
       root.setAttribute('data-theme', resolved);
       root.setAttribute('data-theme-pref', p);
       if (window.__wsAccent) window.__wsAccent(resolved);
-      if (iconEl) iconEl.innerHTML = ICONS[p];
-      if (labelEl) labelEl.textContent = LABELS[p];
     }
-    var themeBtn = document.getElementById('ws-theme');
-    if (themeBtn) themeBtn.addEventListener('click', function () {
-      var next = ORDER[(ORDER.indexOf(readPref()) + 1) % ORDER.length];
-      try { localStorage.setItem(TKEY, next); } catch (e) {}
-      applyTheme();
-    });
     mql.addEventListener('change', function () { if (readPref() === 'system') applyTheme(); });
     // Theme/accent changed in another document (e.g. the Settings page
     // running in the shell iframe) → re-apply to the shell.


### PR DESCRIPTION
Removes the five red-boxed elements from the user's dashboard screenshot:

- Topbar "← Dashboard" back chip and "New tab" chip (sidebar handles navigation; router no longer toggles them)
- Theme cycle button — theme is set in Settings → Appearance; the shell still applies the stored preference (including live cross-document updates)
- "Import Data" topbar button (duplicated the sidebar Data Hub promo)
- Sidebar REVIEW section — its only item was the deferred Site Map "Soon" chip

Dead CSS (.ws-back / .ws-newtab / .ws-themebtn / .ws-importbtn / .is-soon / .ws-badge--soon) and the now-unreferenced JS pruned. Verified headless: removed elements gone, hamburger/bell/profile/Data Hub/Settings intact, theme applies from the stored preference, sidebar → tool → Dashboard routing works, dashboard renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XCGeYGJDd37BwJAZJcoSW