### PR TITLE
Fix account import gaps: Account Number collision + backfill duplicates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -751,6 +751,18 @@ Phase 13u (account names + tax-treatment tracking):
   tiles $20,000/$7,500/$3,000 (exact), datalist lists all registry
   names, typing "New HSA Account" into a row auto-registers HSA/Tax
   Free within the 400ms sync debounce.
+- **13u follow-up fixes** (user found import/paste gaps): both column
+  detectors now prefer "Account Name" and NEVER auto-map "Account
+  Number" (Fidelity/Schwab carry both; the number column comes first
+  in the file, so bare 'account' substring matching grabbed opaque
+  numbers). And both merge paths gained a **backfill rule**: a CSV row
+  that only matches on ticker ADOPTS the CSV's account when the
+  existing holding has none, instead of duplicating the position —
+  re-importing the same file with an Account column now fills accounts
+  in place (hub preview's New/Update status matches). Verified: tracker
+  CSV plain-account + Fidelity-style dual-column (names not numbers,
+  auto-registered treatments), tracker + hub backfill each keep 1 row,
+  hub paste never leaks the account number.
 
 ## Constraints to preserve
 

--- a/data_hub.html
+++ b/data_hub.html
@@ -545,7 +545,15 @@ AAPL,50,142.80,2023-01-10,Schwab 401(k)"></textarea>
       var tk = findCol(headers, ['ticker', 'symbol']);
       var sh = findCol(headers, ['shares', 'quantity', 'qty']);
       var cb = findCol(headers, ['cost basis total', 'average cost basis', 'cost basis', 'cost_basis', 'cost']);
-      var ac = findCol(headers, ['account']);
+      // Prefer "Account Name"; never auto-map "Account Number" (Fidelity/
+      // Schwab carry both and the number column comes first in the file).
+      var ac = findCol(headers, ['account name', 'account_name']);
+      if (ac < 0) {
+        var lowH = headers.map(function (h) { return String(h || '').toLowerCase(); });
+        for (var ai = 0; ai < lowH.length; ai++) {
+          if (lowH[ai].indexOf('account') >= 0 && !/number|nbr|#/.test(lowH[ai])) { ac = ai; break; }
+        }
+      }
       var pd = findCol(headers, ['purchase date', 'purchase_date', 'date acquired', 'acquisition date', 'acquired', 'trade date', 'open date']);
       // Fallback for 3-col generic (ticker,shares,cost_basis) with odd headers
       if (tk < 0 && headers.length >= 3) { tk = 0; sh = 1; cb = 2; }
@@ -563,7 +571,7 @@ AAPL,50,142.80,2023-01-10,Schwab 401(k)"></textarea>
         var ticker = String(c[mapping.tk] || '').toUpperCase();
         if (!ticker) return null;
         var account = mapping.ac >= 0 ? (c[mapping.ac] || '') : '';
-        var already = existing.some(function (h) { return h.ticker === ticker && (!account || h.account === account); });
+        var already = existing.some(function (h) { return h.ticker === ticker && (!account || !h.account || h.account === account); });
         var status = already ? 'update' : 'new';
         if (account && acctNames.length && acctNames.indexOf(account) < 0) status = 'warn';
         var shares = mapping.sh >= 0 ? num(c[mapping.sh]) : 0;
@@ -637,8 +645,12 @@ AAPL,50,142.80,2023-01-10,Schwab 401(k)"></textarea>
       var hs = holdings();
       parsed.forEach(function (r) {
         var idx = hs.findIndex(function (h) { return h.ticker === r.ticker && (h.account || '') === (r.account || ''); });
+        // Backfill: a ticker row with no account yet adopts the CSV's
+        // account instead of duplicating the position.
+        if (idx < 0 && r.account) idx = hs.findIndex(function (h) { return h.ticker === r.ticker && !h.account; });
         if (idx >= 0) {
           hs[idx].shares = r.shares; hs[idx].costBasis = r.costBasis;
+          if (r.account && !hs[idx].account) hs[idx].account = r.account;
           if (r.purchaseDate) hs[idx].purchaseDate = r.purchaseDate;
         }
         // `id` is required by the Portfolio Tracker (row edit/delete key on it)

--- a/portfolio_tracker.html
+++ b/portfolio_tracker.html
@@ -160,7 +160,14 @@
       if (tickerCol < 0 || sharesCol < 0)
         throw new Error(`Could not find ticker/shares columns (detected: ${fmt}). Headers: ${headers.slice(0,6).join(', ')}`);
       const dateCol = col('purchase date', 'purchase_date', 'date acquired', 'acquisition date', 'acquired', 'trade date', 'open date');
-      const acctCol = col('account');
+      // Prefer "Account Name" and never grab "Account Number" — Fidelity/
+      // Schwab exports carry both, and a bare 'account' substring match
+      // would land on the number column (it comes first in the file).
+      const acctCol = (() => {
+        const named = col('account name', 'account_name');
+        if (named >= 0) return named;
+        return hLow.findIndex(h => h.includes('account') && !/number|nbr|#/.test(h));
+      })();
 
       const results = [];
       for (let i = headerIdx + 1; i < lines.length; i++) {
@@ -377,11 +384,14 @@
             // Merge: update existing tickers, append new ones. When the CSV
             // names an account, match on ticker+account (same key as the
             // Data Hub) so the same ticker can live in several accounts.
+            // Backfill: a row that only matches on ticker ADOPTS the CSV's
+            // account when its own is unset, instead of duplicating.
             setHoldings(prev => {
               const merged = [...prev];
               for (const p of parsed) {
-                const idx = merged.findIndex(h => h.ticker === p.ticker &&
+                let idx = merged.findIndex(h => h.ticker === p.ticker &&
                   (p.account == null || (h.account || '') === p.account));
+                if (idx < 0 && p.account) idx = merged.findIndex(h => h.ticker === p.ticker && !h.account);
                 if (idx >= 0) {
                   merged[idx] = { ...merged[idx], shares: p.shares, costBasis: p.costBasis ?? merged[idx].costBasis,
                     purchaseDate: p.purchaseDate ?? merged[idx].purchaseDate,
@@ -485,7 +495,7 @@
           {importMsg && (
             <div className={`mb-3 px-4 py-2 rounded-lg text-sm ${importMsg.startsWith('Import failed') ? 'bg-red-50 text-red-700' : 'bg-emerald-50 text-emerald-700'}`}>
               {importMsg}
-              <span className="text-xs text-gray-400 ml-2">Supports: Fidelity, Schwab, Vanguard, Generic (ticker,shares,cost_basis)</span>
+              <span className="text-xs text-gray-400 ml-2">Supports: Fidelity, Schwab, Vanguard, Generic (ticker,shares,cost_basis) · optional: Account Name, Purchase Date columns</span>
             </div>
           )}
 


### PR DESCRIPTION
Follow-up to #34 — the user reported Account Name not coming through on import/paste. Two real gaps:

1. **"Account Number" collision** — Fidelity/Schwab exports carry both "Account Number" and "Account Name" columns, with the number first. Bare `account` substring matching in both the tracker's CSV parser and the hub's auto-mapper grabbed the *number* column. Both detectors now prefer "Account Name" and skip any header containing number/nbr/#.
2. **Backfill duplicates** — existing holdings (imported before accounts existed) have no account, so re-importing the same CSV *with* an Account column failed the ticker+account match and appended duplicate positions. Both merge paths (tracker import, hub commit) now let a ticker-only match **adopt** the CSV's account when the existing row has none; the hub preview's New/Update status matches.

Also: tracker import hint now mentions the optional Account Name / Purchase Date columns.

## Verified (headless)
- Tracker CSV with plain `account` column → accounts land, treatment tiles correct
- Fidelity-style dual-column CSV → holdings get "Joint Brokerage"/"Roth IRA" (names, not X123456), auto-registered as Taxable / Tax Free
- Backfill re-import: 1 row before and after, account filled in (tracker and hub)
- Hub paste with Account Number + Account Name → preview and commit use the name; the number never leaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XCGeYGJDd37BwJAZJcoSW