### PR TITLE
Hub import: optional Account Type column + helper text update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -751,6 +751,16 @@ Phase 13u (account names + tax-treatment tracking):
   tiles $20,000/$7,500/$3,000 (exact), datalist lists all registry
   names, typing "New HSA Account" into a row auto-registers HSA/Tax
   Free within the 400ms sync debounce.
+- **13u follow-up 2 — optional "Account Type" import column**: hub
+  import/paste accepts an "Account Type" / "Tax Treatment" column
+  (normalized via `normTreatLabel` — taxable/cash, tax free/roth/hsa,
+  tax deferred/traditional → the three canonical labels; unrecognized
+  → name-based guess). On commit it sets the treatment for newly
+  auto-registered accounts and FILLS blank treatments on existing
+  registry entries (never overwrites a curated value). Mapping editor
+  gained an "Account type" select; paste placeholder + Accepted-columns
+  hint document the full column set (and that Account Number is never
+  used).
 - **13u follow-up fixes** (user found import/paste gaps): both column
   detectors now prefer "Account Name" and NEVER auto-map "Account
   Number" (Fidelity/Schwab carry both; the number column comes first

--- a/data_hub.html
+++ b/data_hub.html
@@ -206,10 +206,11 @@
         </div>
         <input type="file" id="dh-file" accept=".csv,text/csv" hidden>
         <button class="dh-paste" id="dh-paste-toggle" type="button">Paste rows instead</button>
-        <textarea class="dh-textarea" id="dh-paste-area" hidden placeholder="Ticker,Shares,Cost Basis,Purchase Date,Account
-VTI,120,165.34,06/15/2020,Fidelity Brokerage
-AAPL,50,142.80,2023-01-10,Schwab 401(k)"></textarea>
-        <div class="dh-hint" style="line-height:1.5;">Accepted columns: Ticker, Shares, Cost Basis (per share; "…Total" headers auto-divide), Account, Purchase Date ("Acquisition Date" / "Date Acquired" / "Trade Date" auto-map — feeds the dashboard Performance table). Fidelity / Schwab / Vanguard headers auto-map; extra columns are ignored.</div>
+        <textarea class="dh-textarea" id="dh-paste-area" hidden placeholder="Ticker,Shares,Cost Basis,Purchase Date,Account,Account Type
+VTI,120,165.34,06/15/2020,Fidelity Brokerage,Taxable
+AAPL,50,142.80,2023-01-10,My Roth IRA,Tax Free
+MSFT,25,310.00,11/20/2023,Schwab 401(k),Tax Deferred"></textarea>
+        <div class="dh-hint" style="line-height:1.5;">Accepted columns: Ticker, Shares, Cost Basis (per share; "…Total" headers auto-divide), Account Name ("Account Number" is never used), Purchase Date ("Acquisition Date" / "Date Acquired" / "Trade Date" — feeds the dashboard Performance table), Account Type ("Tax Treatment": Taxable / Tax Free / Tax Deferred — sets the Accounts Registry). Fidelity / Schwab / Vanguard headers auto-map; extra columns are ignored.</div>
       </div>
       <div class="dh-preview" id="dh-preview">
         <div class="dh-empty">Drop or paste a CSV to preview holdings before committing.</div>
@@ -555,13 +556,23 @@ AAPL,50,142.80,2023-01-10,Schwab 401(k)"></textarea>
         }
       }
       var pd = findCol(headers, ['purchase date', 'purchase_date', 'date acquired', 'acquisition date', 'acquired', 'trade date', 'open date']);
+      var at = findCol(headers, ['account type', 'account_type', 'tax treatment', 'tax_treatment']);
       // Fallback for 3-col generic (ticker,shares,cost_basis) with odd headers
       if (tk < 0 && headers.length >= 3) { tk = 0; sh = 1; cb = 2; }
       // Store convention (Portfolio Tracker): costBasis is PER-SHARE.
       // Vanguard-style "... total" headers carry lot totals → divide by
       // shares; "average"/generic cost headers are already per-share.
       var costIsTotal = cb >= 0 && headers[cb] != null && /total/i.test(headers[cb]);
-      return { tk: tk, sh: sh, cb: cb, ac: ac, pd: pd, costIsTotal: costIsTotal, custom: false };
+      return { tk: tk, sh: sh, cb: cb, ac: ac, pd: pd, at: at, costIsTotal: costIsTotal, custom: false };
+    }
+    // Normalize a CSV "Account Type" / "Tax Treatment" cell to the registry's
+    // three canonical labels; null when unrecognized (fall back to the guess).
+    function normTreatLabel(v) {
+      var n = String(v || '').toLowerCase().replace(/[^a-z]/g, '');
+      if (n === 'taxfree' || n === 'roth' || n === 'hsa') return 'Tax Free';
+      if (n === 'taxdeferred' || n === 'traditional' || n === 'deferred') return 'Tax Deferred';
+      if (n === 'taxable' || n === 'cash') return 'Taxable';
+      return null;
     }
     function buildParsed() {
       if (!rawImport || !mapping || mapping.tk < 0) { parsed = []; return; }
@@ -578,7 +589,8 @@ AAPL,50,142.80,2023-01-10,Schwab 401(k)"></textarea>
         var rawCost = mapping.cb >= 0 ? num(c[mapping.cb]) : 0;
         var costPerShare = (mapping.costIsTotal && rawCost && shares) ? rawCost / shares : rawCost;
         var purchaseDate = mapping.pd >= 0 ? parseDate(c[mapping.pd]) : null;
-        return { ticker: ticker, shares: shares, costBasis: costPerShare, account: account, purchaseDate: purchaseDate, status: status };
+        var acctType = mapping.at >= 0 ? normTreatLabel(c[mapping.at]) : null;
+        return { ticker: ticker, shares: shares, costBasis: costPerShare, account: account, purchaseDate: purchaseDate, acctType: acctType, status: status };
       }).filter(Boolean);
     }
     function mapSelect(field, label) {
@@ -599,7 +611,7 @@ AAPL,50,142.80,2023-01-10,Schwab 401(k)"></textarea>
         ? '<span class="dh-ok">Custom mapping</span>'
         : '<span class="dh-ok"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="20 6 9 17 4 12"></polyline></svg>Columns mapped automatically</span>';
       var mapPanel = mapOpen
-        ? '<div class="dh-map">' + mapSelect('tk', 'Ticker') + mapSelect('sh', 'Shares') + mapSelect('cb', 'Cost basis') + mapSelect('ac', 'Account') + mapSelect('pd', 'Purchase date') +
+        ? '<div class="dh-map">' + mapSelect('tk', 'Ticker') + mapSelect('sh', 'Shares') + mapSelect('cb', 'Cost basis') + mapSelect('ac', 'Account') + mapSelect('pd', 'Purchase date') + mapSelect('at', 'Account type') +
           '<label><input type="checkbox" id="dh-map-total"' + (mapping.costIsTotal ? ' checked' : '') + '> Cost column is a lot total (÷ shares)</label></div>'
         : '';
       var rowsHtml = parsed.length
@@ -669,9 +681,15 @@ AAPL,50,142.80,2023-01-10,Schwab 401(k)"></textarea>
       }
       var accts = accounts();
       parsed.forEach(function (r) {
-        if (r.account && !accts.some(function (a) { return a.name === r.account; })) {
+        if (!r.account) return;
+        var existing = null;
+        for (var xi = 0; xi < accts.length; xi++) { if (accts[xi].name === r.account) { existing = accts[xi]; break; } }
+        if (existing) {
+          // CSV names a treatment and the registry entry has none → fill it
+          if (r.acctType && !existing.taxTreatment) existing.taxTreatment = r.acctType;
+        } else {
           var g = guessAcct(r.account);
-          accts.push({ id: uid(), name: r.account, type: g.type, owner: '', taxTreatment: g.taxTreatment });
+          accts.push({ id: uid(), name: r.account, type: g.type, owner: '', taxTreatment: r.acctType || g.taxTreatment });
         }
       });
       store.set('accounts', accts, EDIT);


### PR DESCRIPTION
Per user request: the paste example and "Accepted columns" helper text lagged the account features — and rather than only fixing the text, the import now actually accepts the column the text advertises.

## New: Account Type / Tax Treatment column
- Auto-maps headers `Account Type` / `Tax Treatment` (plus underscore variants); tolerant value normalization (taxable/cash · tax free/roth/hsa · tax deferred/traditional → the three canonical labels; unrecognized values fall back to the name-based guess).
- On commit: sets the treatment for newly auto-registered accounts and **fills blank treatments** on existing registry entries — never overwrites a value you curated in the registry.
- "Edit mapping" panel gained an **Account type** select.

## Helper text
- Paste placeholder now shows the full example: `Ticker,Shares,Cost Basis,Purchase Date,Account,Account Type` with all three treatments illustrated.
- Accepted-columns hint documents Account Name (noting Account Number is never used), Purchase Date, and Account Type.

## Verified (headless)
Pasting exactly the placeholder example + a row against a pre-seeded blank-treatment account: mapping editor auto-maps the column, registry lands Taxable / Tax Free / Tax Deferred as specified, the blank entry gets filled, holdings carry accounts + ISO purchase dates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XCGeYGJDd37BwJAZJcoSW