### PR TITLE
Fix 'Tax Free' account names not recognized in the tracker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -751,6 +751,16 @@ Phase 13u (account names + tax-treatment tracking):
   tiles $20,000/$7,500/$3,000 (exact), datalist lists all registry
   names, typing "New HSA Account" into a row auto-registers HSA/Tax
   Free within the 400ms sync debounce.
+- **13u follow-up 3 — "Tax Free" account names not recognized** (user
+  report): the name guesser only knew roth/hsa/401k-style patterns, so
+  an account literally named "… Tax Free …" classified as Taxable.
+  Both guessers (tracker + hub) now match tax-free / tax-exempt / 529
+  → Tax Free and tax-deferred → Tax Deferred. Also: the tracker's
+  registry lookup is now case/whitespace-insensitive (`acctKey`) so a
+  typed variant of a curated account resolves; and auto-registration
+  moved OUT of the debounced sync (which registered half-typed names
+  on a >400ms typing pause) to complete-name moments only — add-form
+  submit, CSV import, and Account-input blur (`registerAccounts`).
 - **13u follow-up 2 — optional "Account Type" import column**: hub
   import/paste accepts an "Account Type" / "Tax Treatment" column
   (normalized via `normTreatLabel` — taxable/cash, tax free/roth/hsa,

--- a/data_hub.html
+++ b/data_hub.html
@@ -676,6 +676,7 @@ MSFT,25,310.00,11/20/2023,Schwab 401(k),Tax Deferred"></textarea>
         var n = String(name).toLowerCase();
         if (/roth/.test(n)) return { type: 'Roth', taxTreatment: 'Tax Free' };
         if (/hsa/.test(n)) return { type: 'HSA', taxTreatment: 'Tax Free' };
+        if (/tax[\s._-]*free|tax[\s._-]*exempt|529/.test(n)) return { type: 'Other', taxTreatment: 'Tax Free' };
         if (/401|403|457|ira|trad|sep\b|pension|deferred/.test(n)) return { type: 'Traditional', taxTreatment: 'Tax Deferred' };
         return { type: 'Taxable', taxTreatment: 'Taxable' };
       }

--- a/portfolio_tracker.html
+++ b/portfolio_tracker.html
@@ -230,23 +230,48 @@
         const n = String(name || '').toLowerCase();
         if (/roth/.test(n)) return { type: 'Roth', taxTreatment: 'Tax Free' };
         if (/hsa/.test(n)) return { type: 'HSA', taxTreatment: 'Tax Free' };
-        if (/401|403|457|ira|trad|sep\b|pension|deferred/.test(n)) return { type: 'Traditional', taxTreatment: 'Tax Deferred' };
+        if (/tax[\s._-]*free|tax[\s._-]*exempt|529/.test(n)) return { type: 'Other', taxTreatment: 'Tax Free' };
+        if (/401|403|457|ira|trad|sep\b|pension|tax[\s._-]*deferred|deferred/.test(n)) return { type: 'Traditional', taxTreatment: 'Tax Deferred' };
         return { type: 'Taxable', taxTreatment: 'Taxable' };
       }
       function normTreat(v) {
         const n = String(v || '').toLowerCase().replace(/[^a-z]/g, '');
-        if (n === 'taxfree' || n === 'roth' || n === 'hsa') return 'taxFree';
+        if (n === 'taxfree' || n === 'taxexempt' || n === 'roth' || n === 'hsa') return 'taxFree';
         if (n === 'taxdeferred' || n === 'traditional') return 'taxDeferred';
         if (n === 'taxable' || n === 'cash') return 'taxable';
         return null;
       }
+      // Registry lookup is case/whitespace-insensitive so a typed variant
+      // ("my roth ira ") still resolves to the registered account.
+      const acctKey = (n) => String(n || '').trim().toLowerCase();
       const acctTreat = {};
       accounts.forEach(a => {
-        acctTreat[a.name] = normTreat(a.taxTreatment) || normTreat(a.type) || normTreat(guessAcct(a.name).taxTreatment);
+        acctTreat[acctKey(a.name)] = normTreat(a.taxTreatment) || normTreat(a.type) || normTreat(guessAcct(a.name).taxTreatment);
       });
       function treatOf(h) {
-        if (!h.account) return 'unassigned';
-        return acctTreat[h.account] || normTreat(guessAcct(h.account).taxTreatment);
+        const key = acctKey(h.account);
+        if (!key) return 'unassigned';
+        return acctTreat[key] || normTreat(guessAcct(h.account).taxTreatment);
+      }
+
+      // Register unknown account names into the hub's registry (guessed
+      // type + treatment, curate in the Data Hub). Called at COMPLETE-name
+      // moments — add-form submit, CSV import, Account-input blur — never
+      // from the debounced sync, which used to register half-typed names.
+      function registerAccounts(names) {
+        const clean = [...new Set(names.map(n => String(n || '').trim()).filter(Boolean))];
+        if (!clean.length) return;
+        setAccounts(prev => {
+          const known = new Set(prev.map(a => acctKey(a.name)));
+          const add = clean.filter(n => !known.has(n.toLowerCase()));
+          if (!add.length) return prev;
+          const next = [...prev, ...add.map(n => ({
+            id: 'a-' + Date.now() + '-' + Math.random().toString(36).slice(2, 6),
+            name: n, owner: '', ...guessAcct(n),
+          }))];
+          if (store) store.set('accounts', next, { editedBy: 'tracker' });
+          return next;
+        });
       }
 
       // Sync to suite store (debounced)
@@ -269,21 +294,8 @@
           store.set('portfolio.holdings', holdings, { editedBy: 'tracker' });
           if (totalValue > 0) store.set('portfolio.totalValue', totalValue, { editedBy: 'tracker' });
           if (Object.keys(allocs).length) store.set('portfolio.allocations', allocs, { editedBy: 'tracker' });
-          // Auto-register account names the registry doesn't know yet
-          // (same behavior as the Data Hub's CSV commit) so type / tax
-          // treatment can be curated there.
-          const known = new Set(accounts.map(a => a.name));
-          const unknown = [...new Set(holdings.map(h => h.account).filter(Boolean))].filter(n => !known.has(n));
-          if (unknown.length) {
-            const next = [...accounts, ...unknown.map(n => ({
-              id: 'a-' + Date.now() + '-' + Math.random().toString(36).slice(2, 6),
-              name: n, owner: '', ...guessAcct(n),
-            }))];
-            store.set('accounts', next, { editedBy: 'tracker' });
-            setAccounts(next);
-          }
         }, 400);
-      }, [holdings, accounts]);
+      }, [holdings]);
 
       // ── Derived values ──────────────────────────────────────────────────────
       const totalValue  = holdings.reduce((s, h) => s + (h.currentPrice || 0) * (h.shares || 0), 0);
@@ -351,6 +363,7 @@
           assetClass:     addForm.assetClass,
         };
         setHoldings(prev => [...prev, newH]);
+        if (newH.account) registerAccounts([newH.account]);
         setAddForm({ ticker: '', shares: '', costBasis: '', purchaseDate: '', account: '', assetClass: 'equity' });
         // Try fetching price immediately
         setPxStatus(s => ({ ...s, [ticker]: 'loading' }));
@@ -403,6 +416,7 @@
               }
               return merged;
             });
+            registerAccounts(parsed.map(p => p.account));
             setImportMsg(`Imported ${parsed.length} holdings from ${format} CSV.`);
           } catch (err) {
             setImportMsg(`Import failed: ${err.message}`);
@@ -590,6 +604,7 @@
                             <td className="px-3 py-2">
                               <input value={h.account ?? ''} list="ws-acct-list" placeholder="—"
                                 onChange={e => updateHolding(h.id, 'account', e.target.value || null)}
+                                onBlur={e => registerAccounts([e.target.value])}
                                 className="w-32 border border-gray-200 rounded px-2 py-0.5 text-sm" />
                               {h.account && (
                                 <div className="text-xs text-gray-400 mt-0.5">


### PR DESCRIPTION
User report: entering an account with 'Tax Free' in its name in the Portfolio Tracker wasn't recognized — it landed in the Taxable tile.

## Root causes and fixes
1. **Guesser gap** — the name-based guesser only knew roth/hsa/401k/ira-style patterns, so "Vanguard Tax Free Fund" auto-registered and classified as Taxable. Both guessers (tracker + hub) now match `tax-free` / `tax free` / `tax-exempt` / `529` → Tax Free and `tax-deferred` → Tax Deferred.
2. **Case/whitespace-sensitive lookup** — a holding typed as "my brokerage " didn't match the curated registry entry "My Brokerage" and fell back to the guess. The tracker's registry lookup now normalizes (trim + lowercase).
3. **Half-typed registrations** — auto-registration lived in the 400ms-debounced sync effect, so pausing mid-typing registered junk like "Vang" as accounts. Registration now happens only at complete-name moments: add-form submit, CSV import, and Account-input blur.

## Verified (headless)
- "my brokerage " (variant of curated Tax Free entry) + unregistered "Vanguard Tax Free Fund" → both classified Tax Free, tile reads exactly $27,000
- Typing "Vang" then pausing past the sync debounce → no junk registration
- Blur after typing "Spouse Tax-Free 529" → registered as Tax Free

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XCGeYGJDd37BwJAZJcoSW