### PR TITLE
Data Hub: inline Type / Tax Treatment editing in the Accounts Registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -751,6 +751,16 @@ Phase 13u (account names + tax-treatment tracking):
   tiles $20,000/$7,500/$3,000 (exact), datalist lists all registry
   names, typing "New HSA Account" into a row auto-registers HSA/Tax
   Free within the 400ms sync debounce.
+- **13u follow-up 4 — inline registry editing** (user still saw
+  Taxable after follow-up 3): the registry LOOKUP deliberately beats
+  the name guess, so accounts auto-registered as Taxable by the
+  pre-fix guesser stayed Taxable — and the registry only offered
+  delete + re-add. The hub's Accounts Registry rows now render Type
+  and Tax Treatment as inline `.dh-rowsel` selects (delegated `change`
+  handler → `store.set('accounts')`; unknown legacy values are kept as
+  an extra option). Tools pick edits up on their next load. Verified:
+  stale "Tax Free"=Taxable entry flipped via the select → tracker tile
+  reclassifies $20k to Tax Free on reload.
 - **13u follow-up 3 — "Tax Free" account names not recognized** (user
   report): the name guesser only knew roth/hsa/401k-style patterns, so
   an account literally named "… Tax Free …" classified as Taxable.

--- a/data_hub.html
+++ b/data_hub.html
@@ -127,6 +127,8 @@
     .dh-form[hidden] { display: none; }
     .dh-form input, .dh-form select { font-size: 12px; color: var(--text); background: var(--surface-2); border: 1px solid var(--border); border-radius: 8px; padding: 7px 9px; font-family: inherit; }
     .dh-form input:focus, .dh-form select:focus { outline: none; border-color: var(--primary); }
+    .dh-rowsel { font-size: 12px; color: var(--text); background: var(--surface-2); border: 1px solid var(--border); border-radius: 8px; padding: 4px 6px; font-family: inherit; max-width: 100%; cursor: pointer; }
+    .dh-rowsel:focus { outline: none; border-color: var(--primary); }
 
     /* asset/liability rows */
     .dh-2col { display: grid; grid-template-columns: 1.4fr 1fr; gap: 18px; }
@@ -405,6 +407,20 @@ MSFT,25,310.00,11/20/2023,Schwab 401(k),Tax Deferred"></textarea>
     }
 
     // ---------- accounts ----------
+    var ACCT_TYPES = ['Taxable', 'Roth', 'Traditional', 'HSA', 'Cash', 'Other'];
+    var ACCT_TREATMENTS = ['Taxable', 'Tax Free', 'Tax Deferred'];
+    // Inline select for a registry row — Type and Tax Treatment are
+    // editable in place (auto-registered guesses often need correcting,
+    // and the tracker's per-treatment tiles read taxTreatment).
+    function acctSelect(a, field, options) {
+      var cur = a[field] || '';
+      var opts = options.map(function (o) {
+        return '<option' + (o === cur ? ' selected' : '') + '>' + o + '</option>';
+      }).join('');
+      if (cur && options.indexOf(cur) < 0) opts = '<option selected>' + esc(cur) + '</option>' + opts;
+      if (!cur) opts = '<option value="" selected>—</option>' + opts;
+      return '<select class="dh-rowsel" data-acct-field="' + field + '" data-acct-id="' + esc(a.id) + '">' + opts + '</select>';
+    }
     function renderAccounts() {
       var rows = accounts();
       var host = $('dh-acct-rows');
@@ -412,9 +428,9 @@ MSFT,25,310.00,11/20/2023,Schwab 401(k),Tax Deferred"></textarea>
       host.innerHTML = rows.map(function (a) {
         return '<div class="dh-trow">' +
           '<span class="dh-td" style="font-weight:500;">' + esc(a.name) + '</span>' +
-          '<span class="dh-td--2">' + esc(a.type || '—') + '</span>' +
+          '<span class="dh-td--2">' + acctSelect(a, 'type', ACCT_TYPES) + '</span>' +
           '<span class="dh-td--2">' + esc(a.owner || '—') + '</span>' +
-          '<span class="dh-td--2">' + esc(a.taxTreatment || '—') + '</span>' +
+          '<span class="dh-td--2">' + acctSelect(a, 'taxTreatment', ACCT_TREATMENTS) + '</span>' +
           '<span class="dh-td--2 dh-td--r dh-mono">' + acctCount(a.name) + '</span>' +
           '<span class="dh-td dh-td--r dh-mono" style="font-weight:500;">' + fmtM(acctValue(a.name)) + '</span>' +
           '<span class="dh-td--r"><button class="dh-del" data-del-acct="' + esc(a.id) + '" title="Remove">×</button></span>' +
@@ -1052,6 +1068,20 @@ MSFT,25,310.00,11/20/2023,Schwab 401(k),Tax Deferred"></textarea>
         store.set('liabilities.total', items.reduce(function (s, l) { return s + num(l.balance); }, 0), EDIT);
       }
       renderAll();
+    });
+
+    // inline registry edits (delegated) — Type / Tax Treatment selects
+    document.body.addEventListener('change', function (e) {
+      var sel = e.target.closest && e.target.closest('select[data-acct-field]');
+      if (!sel || !sel.value) return;
+      var id = sel.getAttribute('data-acct-id');
+      var field = sel.getAttribute('data-acct-field');
+      var a = accounts();
+      for (var i = 0; i < a.length; i++) {
+        if (a[i].id === id) { a[i][field] = sel.value; break; }
+      }
+      store.set('accounts', a, EDIT);
+      flash('Account updated — tools pick this up on their next load.');
     });
 
     // last-import label from holdings


### PR DESCRIPTION
User report: entering "Tax Free" in the tracker's Account field still classified as Taxable, even after #37.

## Diagnosis (reproduced both ways)
The #37 code fix works — a **fresh** account named "Tax Free" classifies correctly. The user's store, however, carries a registry entry auto-registered as *Taxable* by the pre-#37 guesser, and registry data deliberately wins over the name guess (it's curated data). With the registry offering only delete + re-add, there was no reasonable way to correct it.

## Fix
Accounts Registry rows now render **Type** and **Tax Treatment** as inline selects; a delegated change handler writes the store (`editedBy: 'hub'`), unknown legacy values are preserved as an extra option, and the row re-render keeps the new value. Tools pick the change up on their next load.

## Verified (headless)
Seeded the user's exact situation (holding on account "Tax Free", registry entry Taxable) → flipped the inline select to Tax Free → store updated, select survives re-render, tracker tile reclassifies the full $20,000 to Tax Free on reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XCGeYGJDd37BwJAZJcoSW