### PR TITLE
Dashboard chart fixes: stale NW history, range-pill axis, retirement gating (Phase 13v)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -805,6 +805,40 @@ Phase 13u (account names + tax-treatment tracking):
   auto-registered treatments), tracker + hub backfill each keep 1 row,
   hub paste never leaks the account number.
 
+Phase 13v (dashboard chart fixes — user-reported):
+- **NW Growth "stale data"**: the chart draws `wealthSuite.nwHistory`
+  (device-local daily snapshots), which faithfully includes test-era
+  junk — and `store.reset()` never touched it, so a cleaned store kept
+  charting old values. Settings Reset now also clears the device
+  caches (nwHistory/perfSeries/briefingStats/briefingNarrative) via
+  `clearDeviceCaches()`, and Data Controls gained a standalone
+  **"Clear chart history"** button (fix a poisoned chart without
+  losing real data; history re-accrues from the next dashboard visit).
+- **Range pills**: they always re-windowed the data, but with < 1 yr
+  of snapshots every window is identical — invisible. Now the x-axis
+  granularity follows the VISIBLE window's actual span (≤70d → "Jul
+  18", ≤550d → months, ≤1500d → quarters "Q3 '25", else years;
+  consecutive duplicates blanked), and the card subtitle (`#ws-nw-sub`)
+  states the selected range AND recorded span ("1Y view · 9 days of
+  daily snapshots …") so "no effect" is self-explaining.
+- **Retirement Planning card**: three fixes. (1) retire age now falls
+  back active scenario → plan.targetRetireAge → spouses'
+  targetRetireAge (index.html doesn't load suite.js, so the scenario
+  precedence is replicated inline, matching the Roth/MC adapters).
+  (2) **growthAssumption unit bug**: the card did `(v||7)/100`, but
+  the store convention is a FRACTION (0.07) → mean 0.0007 silently
+  wrecked the simulation whenever the plan was populated; now
+  normalized (>1 → percent, else fraction, default 0.07). (3) When
+  still gated on a non-empty store, `#ws-ret-sub` names the missing
+  inputs ("Sample — add household ages + annual expenses …") instead
+  of silently showing the mockup.
+- Verified headless: 24-mo seeded history → 1Y pill months axis +
+  "+$219K", All pill quarters axis + "+$300K", callout tracks the
+  store's live NW; 6-day history → day labels + honest subtitle;
+  scenario-only retire age + 0.07 growth → live card (96%, $6.25M
+  median at 85); missing ages → explanatory sample note; Settings
+  clear-history and Reset both purge the right keys.
+
 ## Constraints to preserve
 
 - **Zero build step.** No Vite/Webpack until scope demands it.

--- a/index.html
+++ b/index.html
@@ -440,7 +440,7 @@
               <div class="ws-cardhead" style="margin-bottom:14px;">
                 <div>
                   <div class="ws-cardtitle">Net Worth Growth</div>
-                  <div class="ws-cardsub">12-month trend · Net worth &amp; top buckets</div>
+                  <div class="ws-cardsub" id="ws-nw-sub">12-month trend · Net worth &amp; top buckets</div>
                 </div>
                 <div class="ws-rangebtns" id="ws-nw-ranges">
                   <button class="ws-rangebtn is-active" type="button" data-months="12">1Y</button>
@@ -1318,18 +1318,41 @@
         '<div class="ws-legend__item"><div class="ws-legend__dash" style="background:var(--cat2);"></div>Investments<span class="ws-legend__val">' + money(lastP.inv) + '</span></div>' +
         '<div class="ws-legend__item"><div class="ws-legend__dash" style="background:var(--cat3);"></div>Retirement<span class="ws-legend__val">' + money(lastP.ret) + '</span></div>' +
         '<div class="ws-legend__item"><div class="ws-legend__dash" style="background:var(--cat4);"></div>Home<span class="ws-legend__val">' + money(lastP.home) + '</span></div>';
+      // X-axis labels: granularity follows the VISIBLE window's actual
+      // span — days → months → quarters → years — with consecutive
+      // duplicates blanked (spacing kept), so the 1Y/3Y/5Y/All pills
+      // visibly change the axis once history spans long enough.
+      var spanDays = Math.max(1, (new Date(lastP.d + 'T12:00:00') - new Date(first.d + 'T12:00:00')) / 86400000);
       var months = document.getElementById('ws-nw-months');
       if (months) {
         var MO = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+        function axisLbl(d) {
+          if (spanDays <= 70) return MO[d.getMonth()] + ' ' + d.getDate();
+          if (spanDays <= 550) return MO[d.getMonth()] + (d.getMonth() === 0 ? " '" + String(d.getFullYear()).slice(2) : '');
+          if (spanDays <= 1500) return 'Q' + (Math.floor(d.getMonth() / 3) + 1) + " '" + String(d.getFullYear()).slice(2);
+          return String(d.getFullYear());
+        }
         var n = Math.min(12, hist.length);
-        var out = '';
+        var out = '', prevLbl = null;
         for (var i = 0; i < n; i++) {
           var p = hist[Math.round(i * (hist.length - 1) / Math.max(1, n - 1))];
           var d = new Date(p.d + 'T12:00:00');
           var isLast = i === n - 1;
-          out += '<span class="ws-date" style="font-size:11.5px;color:' + (isLast ? 'var(--primary-text)' : 'var(--text-3)') + (isLast ? ';font-weight:500' : '') + ';">' + MO[d.getMonth()] + (isLast ? ' ▲' : '') + '</span>';
+          var text = axisLbl(d);
+          var show = isLast || text !== prevLbl;
+          if (show) prevLbl = text;
+          out += '<span class="ws-date" style="font-size:11.5px;color:' + (isLast ? 'var(--primary-text)' : 'var(--text-3)') + (isLast ? ';font-weight:500' : '') + ';">' + (show ? text + (isLast ? ' ▲' : '') : '&nbsp;') + '</span>';
         }
         months.innerHTML = out;
+      }
+      // Subtitle states the selected range AND how much history actually
+      // exists — with days of snapshots, every range shows the same data,
+      // and this is why (history accrues from dashboard visits).
+      var subEl = document.getElementById('ws-nw-sub');
+      if (subEl) {
+        var rname = { 12: '1Y', 36: '3Y', 60: '5Y', 0: 'All' }[nwRangeMonths] || 'All';
+        var covered = spanDays >= 350 ? (Math.round(spanDays / 365.25 * 10) / 10) + ' yrs' : Math.round(spanDays) + ' days';
+        subEl.textContent = rname + ' view · ' + covered + ' of daily snapshots · net worth & top buckets';
       }
     }
 
@@ -1442,14 +1465,36 @@
       var spouses = (s.household && s.household.spouses) || [];
       var ages = spouses.map(function (x) { return Number(x && x.age); }).filter(function (n) { return n > 0; });
       var curAge = ages.length ? Math.min.apply(null, ages) : null;
-      var retAge = Number(plan.targetRetireAge) || null;
+      // Retire age: active scenario overrides the plan (same precedence as
+      // the Roth/MC adapters), then the spouses' Settings targets.
+      var prefs = s.preferences || {};
+      var scens = Array.isArray(prefs.scenarios) ? prefs.scenarios : [];
+      var scen = scens.length ? (scens.filter(function (x) { return x && x.id === prefs.activeScenarioId; })[0] || scens[0]) : null;
+      var retAge = (scen && Number(scen.targetRetireAge)) || Number(plan.targetRetireAge)
+        || (spouses[0] && Number(spouses[0].targetRetireAge)) || (spouses[1] && Number(spouses[1].targetRetireAge)) || null;
       var startBal = (portfolioVal || 0) + (retireBal || 0);
       var expenses = Number(plan.annualExpenses) || (monthlyBudget ? monthlyBudget * 12 : 0);
-      if (!curAge || !retAge || retAge <= curAge || !(startBal > 0) || !(expenses > 0)) return; // keep sample
+      if (!curAge || !retAge || retAge <= curAge || !(startBal > 0) || !(expenses > 0)) {
+        // keep the sample chart, but say WHY it isn't live yet (only once
+        // the store has any data — a fully empty store stays pure sample)
+        if (s.meta && s.meta.lastUpdated != null) {
+          var miss = [];
+          if (!curAge) miss.push('household ages');
+          if (!retAge || (curAge && retAge <= curAge)) miss.push('retirement age');
+          if (!(startBal > 0)) miss.push('portfolio balance');
+          if (!(expenses > 0)) miss.push('annual expenses');
+          var subG = document.getElementById('ws-ret-sub');
+          if (subG && miss.length) subG.textContent = 'Sample — add ' + miss.join(' + ') + ' in Settings / Retirement Plan to go live';
+        }
+        return;
+      }
       var c = (s.retirement && s.retirement.contributions) || {};
       function sumSp(o) { return o ? (Number(o.s1) || 0) + (Number(o.s2) || 0) : 0; }
       var contrib = sumSp(c.traditional401k) + sumSp(c.roth401k) + sumSp(c.afterTax401k) + sumSp(c.catchup) + sumSp(c.ira) + (Number(c.hsa) || 0);
-      var mean = (Number(plan.growthAssumption) || 7) / 100, sd = 0.15;
+      // growthAssumption may be stored as a fraction (0.07, the adapters'
+      // convention) or a percent (7) — normalize either to a fraction
+      var gRaw = Number(plan.growthAssumption) || 0;
+      var mean = gRaw > 1 ? gRaw / 100 : (gRaw > 0 ? gRaw : 0.07), sd = 0.15;
       var END = 95, YRS = END - curAge, SIMS = 1000;
       var rand = mulberry32(Math.round(startBal + expenses * 7 + retAge * 131 + curAge * 17));
       function gauss() { var u = Math.max(rand(), 1e-9), v = rand(); return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v); }

--- a/settings.html
+++ b/settings.html
@@ -258,8 +258,12 @@
           <div><div class="st-rval">Price source</div><div class="st-rsub">Yahoo Finance · free tier</div></div>
           <select class="st-select" id="st-pricesrc"><option value="yahoo">Yahoo Finance</option></select>
         </div>
+        <div class="st-row">
+          <div><div class="st-rval">Clear chart history</div><div class="st-rsub">Deletes this device's net-worth snapshots (the dashboard Growth chart re-accrues from tomorrow)</div></div>
+          <button class="st-btn-outline" id="st-clearhist" type="button">Clear</button>
+        </div>
         <div class="st-row st-row--danger">
-          <div><div class="st-rval st-danger-label">Reset all data</div><div class="st-rsub">Clears holdings, accounts, scenarios</div></div>
+          <div><div class="st-rval st-danger-label">Reset all data</div><div class="st-rsub">Clears holdings, accounts, scenarios + this device's chart caches</div></div>
           <button class="st-btn-danger" id="st-reset" type="button">Reset…</button>
         </div>
       </div>
@@ -453,7 +457,25 @@
       clearTimeout(resetTimer); resetArmed = false;
       this.classList.remove('is-armed'); this.textContent = 'Reset…';
       store.reset({ editedBy: 'reset' });
+      clearDeviceCaches();
       renderAll(); flash('All data cleared.');
+    });
+    // Device-local derived caches live OUTSIDE the store (deliberately),
+    // so store.reset() alone leaves the dashboard Growth chart drawing
+    // stale test-era snapshots. Clear them with the reset — and expose
+    // history-clearing on its own for fixing a poisoned chart without
+    // losing real data.
+    function clearDeviceCaches() {
+      try {
+        localStorage.removeItem('wealthSuite.nwHistory');
+        localStorage.removeItem('wealthSuite.perfSeries');
+        localStorage.removeItem('wealthSuite.briefingStats');
+        localStorage.removeItem('wealthSuite.briefingNarrative');
+      } catch (e) {}
+    }
+    $('st-clearhist').addEventListener('click', function () {
+      try { localStorage.removeItem('wealthSuite.nwHistory'); } catch (e) {}
+      flash('Chart history cleared — the Growth chart restarts from your next dashboard visit.');
     });
 
     // ---------- render ----------


### PR DESCRIPTION
Three user-reported dashboard issues.

## 1. Net Worth Growth showing stale data
The chart draws `wealthSuite.nwHistory` — device-local daily snapshots — which faithfully recorded test-era values, and `store.reset()` never cleared it. So a cleaned store kept charting ~$1M-era junk while the callout (recomputed live) was right.
- Settings **Reset** now also clears the device caches (`nwHistory`, `perfSeries`, `briefingStats`, `briefingNarrative`)
- New **"Clear chart history"** button in Data Controls fixes a poisoned chart without losing real data (history re-accrues from the next dashboard visit)

## 2. Range pills appearing to do nothing
They always re-windowed the data — but with days of snapshots, every window is identical. Now:
- X-axis granularity follows the visible window's actual span: day labels (≤70d), months (≤550d), quarters (≤1500d), years — consecutive duplicates blanked
- The card subtitle states the selected range **and** the recorded span ("1Y view · 9 days of daily snapshots") so the behavior is self-explaining

## 3. Retirement Planning stuck on sample
- Retire age now falls back: active scenario → `plan.targetRetireAge` → spouses' Settings targets (scenario precedence matches the Roth/MC adapters)
- **Unit bug**: the simulation did `(growthAssumption||7)/100`, but the store convention is a fraction (0.07) → mean 0.07% silently wrecked results whenever the plan was populated; now normalized
- When still gated on a non-empty store, the subtitle names the missing inputs instead of silently showing the mockup

## Verified (headless)
24-month seeded history: 1Y pill → month axis, +$219K; All → quarter axis, +$300K; callout tracks the store's live NW. 6-day history → day labels + honest subtitle. Scenario-only retire age + 0.07 fraction growth → live card (96% success, $6.25M median at 85). Missing ages → explanatory note. Settings clear-history and Reset purge exactly the right keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019XCGeYGJDd37BwJAZJcoSW